### PR TITLE
[FEAT] 기업 정보 Swagger 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 	annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/exception/ExceptionType.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/exception/ExceptionType.java
@@ -19,6 +19,9 @@ public enum ExceptionType {
     MEMBER_NOT_FOUND(NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
     MEMBER_INFO_INVALID(UNAUTHORIZED, "U002", "아이디 또는 비밀번호가 일치하지 않습니다."),
 
+    // Company
+    COMPANY_NOT_FOUND(NOT_FOUND,"COM001", "회사를 찾을 수 없습니다."),
+
     // Security
     NEED_AUTHORIZED(UNAUTHORIZED, "S001", "인증이 필요합니다."),
     ACCESS_DENIED(FORBIDDEN, "S002", "접근 권한이 없습니다."),

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/api/CompanyApi.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/api/CompanyApi.java
@@ -1,0 +1,85 @@
+package kr.ac.kumoh.d138.JobForeigner.job.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import kr.ac.kumoh.d138.JobForeigner.global.response.GlobalPageResponse;
+import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
+import kr.ac.kumoh.d138.JobForeigner.job.dto.CompanyDetailResponseDto;
+import kr.ac.kumoh.d138.JobForeigner.job.dto.CompanyResponseDto;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public interface CompanyApi {
+
+    /*
+    기업 리스트 전체조회
+     */
+    @Operation(
+            summary = "기업 정보 전체 조회",
+            description = "기업 정보를 필터링 조건에 따라 페이지네이션하여 전체 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "기업 전체 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = CompanyResponseDto.class))
+                    )
+            )
+    })
+    @GetMapping("/company")
+    public ResponseEntity<ResponseBody<GlobalPageResponse<CompanyResponseDto>>> getAllCompany(
+            @Parameter(description = "기업 이름 검색", example = "google")
+            @RequestParam(required = false) String companyName,
+
+            @Parameter(description = "지역 필터링", example = "서울")
+            @RequestParam(required = false) String region,
+
+            @Parameter(description = "직종 필터링", example = "쇼핑몰")
+            @RequestParam(required = false) String jobType,
+
+            @ParameterObject // Pageable은 springdoc에서 이렇게 처리
+            @PageableDefault(size = 12, sort = "companyName") Pageable pageable
+    );
+
+    /*
+    기업 상세조회
+     */
+    @Operation(
+            summary = "기업 정보 상세조회",
+            description = "기업 ID를 기반으로 상세한 기업 정보를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "기업 상세 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CompanyDetailResponseDto.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "회사를 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ResponseBody.class))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ResponseBody.class))
+            )
+    })
+    @GetMapping("/company/{companyId}")
+    public ResponseEntity<ResponseBody<CompanyDetailResponseDto>> getCompanyDetail(
+            @Parameter(description = "회사 아이디", example = "1", required = true)
+            @PathVariable("companyId") Long companyId
+    );
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/controller/CompanyController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/controller/CompanyController.java
@@ -1,11 +1,12 @@
-package kr.ac.kumoh.d138.JobForeigner.job.domain.controller;
+package kr.ac.kumoh.d138.JobForeigner.job.controller;
 
 import kr.ac.kumoh.d138.JobForeigner.global.response.GlobalPageResponse;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil;
-import kr.ac.kumoh.d138.JobForeigner.job.domain.dto.CompanyDetailResponseDto;
-import kr.ac.kumoh.d138.JobForeigner.job.domain.dto.CompanyResponseDto;
-import kr.ac.kumoh.d138.JobForeigner.job.domain.service.CompanyService;
+import kr.ac.kumoh.d138.JobForeigner.job.api.CompanyApi;
+import kr.ac.kumoh.d138.JobForeigner.job.dto.CompanyDetailResponseDto;
+import kr.ac.kumoh.d138.JobForeigner.job.dto.CompanyResponseDto;
+import kr.ac.kumoh.d138.JobForeigner.job.service.CompanyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-public class CompanyController {
+public class CompanyController implements CompanyApi {
 
     private final CompanyService companyService;
     /*
@@ -27,22 +28,24 @@ public class CompanyController {
     @GetMapping("/company")
     public ResponseEntity<ResponseBody<GlobalPageResponse<CompanyResponseDto>>> getAllCompany(
             @RequestParam(required = false) String companyName,
+
             @RequestParam(required = false) String region,
+
             @RequestParam(required = false) String jobType,
-            @PageableDefault(size=12, sort="companyName") Pageable pageable){
-        Page<CompanyResponseDto> allCompany = companyService.getAllCompany(companyName,region,jobType,pageable);
+
+            @PageableDefault(size = 12, sort = "companyName") Pageable pageable
+    ) {
+        Page<CompanyResponseDto> allCompany = companyService.getAllCompany(companyName, region, jobType, pageable);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(GlobalPageResponse.create(allCompany)));
     }
-    /*
-    기업 리스트 조건 조회
-     */
-
 
     /*
     기업 상세조회
      */
     @GetMapping("/company/{companyId}")
-    public ResponseEntity<ResponseBody<CompanyDetailResponseDto>> getCompanyDetail(@PathVariable("companyId") Long companyId){
+    public ResponseEntity<ResponseBody<CompanyDetailResponseDto>> getCompanyDetail(
+            @PathVariable("companyId") Long companyId
+    ) {
         CompanyDetailResponseDto companyDetail = companyService.getCompanyDetail(companyId);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(companyDetail));
     }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/dto/CompanyDetailResponseDto.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/dto/CompanyDetailResponseDto.java
@@ -1,4 +1,4 @@
-package kr.ac.kumoh.d138.JobForeigner.job.domain.dto;
+package kr.ac.kumoh.d138.JobForeigner.job.dto;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/dto/CompanyInfoDto.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/dto/CompanyInfoDto.java
@@ -1,4 +1,4 @@
-package kr.ac.kumoh.d138.JobForeigner.job.domain.dto;
+package kr.ac.kumoh.d138.JobForeigner.job.dto;
 
 import kr.ac.kumoh.d138.JobForeigner.job.domain.Company;
 import lombok.Builder;

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/dto/CompanyRatingDto.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/dto/CompanyRatingDto.java
@@ -1,4 +1,4 @@
-package kr.ac.kumoh.d138.JobForeigner.job.domain.dto;
+package kr.ac.kumoh.d138.JobForeigner.job.dto;
 
 import kr.ac.kumoh.d138.JobForeigner.job.domain.Company;
 import lombok.Builder;

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/dto/CompanyResponseDto.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/dto/CompanyResponseDto.java
@@ -1,4 +1,4 @@
-package kr.ac.kumoh.d138.JobForeigner.job.domain.dto;
+package kr.ac.kumoh.d138.JobForeigner.job.dto;
 
 import kr.ac.kumoh.d138.JobForeigner.job.domain.Company;
 import lombok.Getter;

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/dto/JobPostDto.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/dto/JobPostDto.java
@@ -1,4 +1,4 @@
-package kr.ac.kumoh.d138.JobForeigner.job.domain.dto;
+package kr.ac.kumoh.d138.JobForeigner.job.dto;
 
 import kr.ac.kumoh.d138.JobForeigner.job.domain.JobPost;
 import lombok.Builder;

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/dto/ReviewDto.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/dto/ReviewDto.java
@@ -1,4 +1,4 @@
-package kr.ac.kumoh.d138.JobForeigner.job.domain.dto;
+package kr.ac.kumoh.d138.JobForeigner.job.dto;
 
 import kr.ac.kumoh.d138.JobForeigner.rating.Rating;
 import lombok.Builder;

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/dto/SalaryInfoDto.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/dto/SalaryInfoDto.java
@@ -1,4 +1,4 @@
-package kr.ac.kumoh.d138.JobForeigner.job.domain.dto;
+package kr.ac.kumoh.d138.JobForeigner.job.dto;
 
 import kr.ac.kumoh.d138.JobForeigner.job.domain.Company;
 import lombok.Builder;

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/repository/CompanyRepository.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/repository/CompanyRepository.java
@@ -1,4 +1,4 @@
-package kr.ac.kumoh.d138.JobForeigner.job.domain.repository;
+package kr.ac.kumoh.d138.JobForeigner.job.repository;
 
 import kr.ac.kumoh.d138.JobForeigner.job.domain.Company;
 import org.springframework.data.domain.Page;

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/repository/JobPostRepository.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/repository/JobPostRepository.java
@@ -1,8 +1,10 @@
-package kr.ac.kumoh.d138.JobForeigner.job.domain.repository;
+package kr.ac.kumoh.d138.JobForeigner.job.repository;
 
 import kr.ac.kumoh.d138.JobForeigner.job.domain.JobPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface JobPostRepository extends JpaRepository<JobPost, Long> {
-    JobPost findByCompanyId(Long companyId);
+    Optional<JobPost> findByCompanyId(Long companyId);
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/service/CompanyService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/service/CompanyService.java
@@ -1,4 +1,4 @@
-package kr.ac.kumoh.d138.JobForeigner.job.domain.service;
+package kr.ac.kumoh.d138.JobForeigner.job.service;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -8,9 +8,9 @@ import kr.ac.kumoh.d138.JobForeigner.job.domain.Company;
 import kr.ac.kumoh.d138.JobForeigner.job.domain.CompanyRating;
 import kr.ac.kumoh.d138.JobForeigner.job.domain.JobPost;
 import kr.ac.kumoh.d138.JobForeigner.job.domain.QCompany;
-import kr.ac.kumoh.d138.JobForeigner.job.domain.dto.*;
-import kr.ac.kumoh.d138.JobForeigner.job.domain.repository.CompanyRepository;
-import kr.ac.kumoh.d138.JobForeigner.job.domain.repository.JobPostRepository;
+import kr.ac.kumoh.d138.JobForeigner.job.dto.*;
+import kr.ac.kumoh.d138.JobForeigner.job.repository.CompanyRepository;
+import kr.ac.kumoh.d138.JobForeigner.job.repository.JobPostRepository;
 import kr.ac.kumoh.d138.JobForeigner.rating.Rating;
 import kr.ac.kumoh.d138.JobForeigner.rating.repository.RatingRepository;
 import lombok.RequiredArgsConstructor;
@@ -76,12 +76,15 @@ public class CompanyService {
 
     public CompanyDetailResponseDto getCompanyDetail(Long id) {
         Company company = companyRepository.findById(id)
-                .orElseThrow(()->new BusinessException(ExceptionType.MEMBER_NOT_FOUND));
-        JobPost jobpost=jobPostRepository.findByCompanyId(company.getId());
+                .orElseThrow(()->new BusinessException(ExceptionType.COMPANY_NOT_FOUND));
+        JobPost jobpost=jobPostRepository.findByCompanyId(company.getId()).orElse(null);
         // 기업 정보 매핑
         CompanyInfoDto companyInfoDto=CompanyInfoDto.fromEntity(company);
         // 채용정보 매핑
-        JobPostDto jobPostDto=JobPostDto.fromEntity(jobpost);
+        JobPostDto jobPostDto = null;
+        if (jobpost != null) {
+            jobPostDto = JobPostDto.fromEntity(jobpost);
+        }
         // 연봉 매핑
         SalaryInfoDto salaryInfoDto=SalaryInfoDto.fromEntity(company);
         // 기업 평점 매핑


### PR DESCRIPTION
## 관련이슈 🚨
- closed #15 

## What is this PR?🔍
- 기업 정보 Swagger 세팅

## Changes💻

-  Swagger 라이브러리 설치
-  Controller API Interface로 비즈니스 코드와 Swagger 분리


## ScreenShot📷
| 오류 응답 | Swagger execute 응답 |
|------------------|-----------------------------|
| ![실제 응답](https://github.com/user-attachments/assets/b83d3616-67e1-439e-a887-d6256803b6c2) | ![문제 응답](https://github.com/user-attachments/assets/bd49dab2-0a52-4c9f-a238-f90e1626bd0b) |

---

- 스웨거에 뜨는 Response가 실제 응답하는 Response와 다른 문제가 발생하고 있습니다. execute로 실제 보내는 요청에서는 정상적으로 뜨는데, 요청을 보내지 않는 예시 응답에서는GlobalResponse, List 형태가 보이지 않고 있습니다.  GPT가 알려준 방식이 2가지 정도가 있는데,
<br>

![image](https://github.com/user-attachments/assets/851736b7-64de-4393-b09d-b4e81400ca64)
- 이 방식은 응답마다 클래스를 생성해야 하므로 비효율적인 방식인거 같습니다.
<br>

![image](https://github.com/user-attachments/assets/5db2998c-4625-40ca-9def-43168b94a198)
- 이 방식은 직접 응답을 추가하는 방식인데, 수작업이다 보니 오류가 발생할 확률이 높고 시간도 매우 오래걸릴거 같습니다.

| 방식 | 설명 | 문제점 |
|------|------|--------|
| ✅ 커스텀 응답 클래스 생성 | `CompanyListResponse`처럼 Wrapper 클래스 생성 | 응답마다 클래스 작성해야 해서 비효율 |
| ✍ ExampleObject 수작업 입력 | JSON 예시 직접 입력 | 실수 가능성 높고 유지보수 힘듦 |

위 방식외에 좋은 방법이 있으면 알려주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new API endpoints for listing companies and retrieving detailed company information, now accompanied by integrated API documentation.

- **Bug Fixes**
  - Improved error messaging for scenarios where company information is unavailable and enhanced data handling to mitigate potential issues.

- **Refactor**
  - Streamlined overall code organization and refined data processing for more consistent and maintainable service delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->