### PR TITLE
토큰 응답 방식 통일

### DIFF
--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/jwt/token/TokenUtils.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/jwt/token/TokenUtils.java
@@ -41,6 +41,8 @@ public class TokenUtils {
      */
     public static void deleteRefreshToken(HttpServletResponse response) {
         Cookie cookie = new Cookie(COOKIE_NAME_REFRESH_TOKEN, null);
+        cookie.setHttpOnly(true);
+//        cookie.setSecure(true);
         cookie.setMaxAge(0);
         cookie.setPath("/tokens/refresh");
         response.addCookie(cookie);

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/jwt/token/TokenUtils.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/jwt/token/TokenUtils.java
@@ -42,6 +42,7 @@ public class TokenUtils {
     public static void deleteRefreshToken(HttpServletResponse response) {
         Cookie cookie = new Cookie(COOKIE_NAME_REFRESH_TOKEN, null);
         cookie.setMaxAge(0);
+        cookie.setPath("/tokens/refresh");
         response.addCookie(cookie);
     }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/jwt/token/TokenUtils.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/jwt/token/TokenUtils.java
@@ -1,0 +1,47 @@
+package kr.ac.kumoh.d138.JobForeigner.global.jwt.token;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.ac.kumoh.d138.JobForeigner.token.dto.JwtPair;
+import org.springframework.http.HttpHeaders;
+
+public class TokenUtils {
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String COOKIE_NAME_REFRESH_TOKEN = "refresh_token";
+
+    /**
+     * AccessToken을 AUTHORIZATION 헤더에 넣고, RefreshToken을 Cookie에 넣습니다.
+     */
+    public static void setAccessTokenAndRefreshToken(HttpServletResponse response, JwtPair tokens) {
+        setAccessToken(response, tokens);
+        setRefreshToken(response, tokens);
+    }
+
+    /**
+     * AccessToken을 AUTHORIZATION 헤더에 넣습니다.
+     */
+    public static void setAccessToken(HttpServletResponse response, JwtPair tokens) {
+        response.addHeader(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + tokens.accessToken());
+    }
+
+    /**
+     * RefreshToken을 Cookie에 넣습니다.
+     */
+    public static void setRefreshToken(HttpServletResponse response, JwtPair tokens) {
+        Cookie cookie = new Cookie(COOKIE_NAME_REFRESH_TOKEN, tokens.refreshToken());
+        cookie.setHttpOnly(true);
+//        cookie.setSecure(true);
+        cookie.setPath("/tokens/refresh");
+        cookie.setMaxAge(tokens.refreshTokenExpiredIn());
+        response.addCookie(cookie);
+    }
+
+    /**
+     * RefreshToken을 Cookie에서 지웁니다.
+     */
+    public static void deleteRefreshToken(HttpServletResponse response) {
+        Cookie cookie = new Cookie(COOKIE_NAME_REFRESH_TOKEN, null);
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/controller/AuthController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/controller/AuthController.java
@@ -1,0 +1,46 @@
+package kr.ac.kumoh.d138.JobForeigner.member.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.TokenUtils;
+import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
+import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil;
+import kr.ac.kumoh.d138.JobForeigner.member.dto.request.SignInRequest;
+import kr.ac.kumoh.d138.JobForeigner.member.service.AuthService;
+import kr.ac.kumoh.d138.JobForeigner.token.dto.JwtPair;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    /**
+     * 외국인 및 기업 사용자 로그인 API
+     */
+    @PostMapping("/sign-in")
+    public ResponseEntity<ResponseBody<Void>> signUp(@RequestBody SignInRequest signInRequest,
+                                                     HttpServletResponse response) {
+        JwtPair tokens = authService.signIn(signInRequest.username(), signInRequest.password());
+        TokenUtils.setAccessTokenAndRefreshToken(response, tokens);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
+    }
+
+    /**
+     * 외국인 및 기업 사용자 로그아웃 API
+     */
+    @DeleteMapping("/sign-out")
+    public ResponseEntity<ResponseBody<Void>> signOut(@AuthenticationPrincipal Long memberId,
+                                                      HttpServletResponse response) {
+        authService.signOut(memberId);
+        TokenUtils.deleteRefreshToken(response);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/controller/CompanyMemberController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/controller/CompanyMemberController.java
@@ -1,0 +1,35 @@
+package kr.ac.kumoh.d138.JobForeigner.member.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.TokenUtils;
+import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
+import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil;
+import kr.ac.kumoh.d138.JobForeigner.member.dto.request.SignUpForCompanyRequest;
+import kr.ac.kumoh.d138.JobForeigner.member.service.CompanyMemberService;
+import kr.ac.kumoh.d138.JobForeigner.token.dto.JwtPair;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class CompanyMemberController {
+    private final CompanyMemberService companyMemberService;
+
+    /**
+     * 기업 사용자 회원가입 API
+     * 기업 사용자는 사업자 인증 후 승인이 완료되면 회원가입을 진행할 수 있습니다.
+     */
+    @PostMapping("/sign-up/company")
+    public ResponseEntity<ResponseBody<Void>> signUpForComapny(@RequestBody @Valid SignUpForCompanyRequest signUpRequest,
+                                                               HttpServletResponse response) {
+        JwtPair tokens = companyMemberService.signUp(signUpRequest);
+        TokenUtils.setAccessTokenAndRefreshToken(response, tokens);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/controller/ForeignerMemberController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/controller/ForeignerMemberController.java
@@ -1,0 +1,34 @@
+package kr.ac.kumoh.d138.JobForeigner.member.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.TokenUtils;
+import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
+import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil;
+import kr.ac.kumoh.d138.JobForeigner.member.dto.request.SignUpForForeignerRequest;
+import kr.ac.kumoh.d138.JobForeigner.member.service.ForeignerMemberService;
+import kr.ac.kumoh.d138.JobForeigner.token.dto.JwtPair;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class ForeignerMemberController {
+    private final ForeignerMemberService foreignerMemberService;
+
+    /**
+     * 외국인 사용자 회원가입 API
+     */
+    @PostMapping("/sign-up/foreigner")
+    public ResponseEntity<ResponseBody<Void>> signUp(@RequestBody @Valid SignUpForForeignerRequest signUpRequest,
+                                                     HttpServletResponse response) {
+        JwtPair tokens = foreignerMemberService.signUp(signUpRequest);
+        TokenUtils.setAccessTokenAndRefreshToken(response, tokens);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/controller/MemberController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/controller/MemberController.java
@@ -1,24 +1,12 @@
 package kr.ac.kumoh.d138.JobForeigner.member.controller;
 
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.Valid;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
-import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil;
-import kr.ac.kumoh.d138.JobForeigner.member.dto.request.SignInRequest;
-import kr.ac.kumoh.d138.JobForeigner.member.dto.request.SignUpRequest;
 import kr.ac.kumoh.d138.JobForeigner.member.dto.response.MemberProfileResponse;
 import kr.ac.kumoh.d138.JobForeigner.member.service.MemberService;
-import kr.ac.kumoh.d138.JobForeigner.token.dto.JwtPair;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,53 +16,7 @@ import static kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil.createS
 @RequestMapping("/api/v1/members")
 @RequiredArgsConstructor
 public class MemberController {
-
-    private static final String BEARER_PREFIX = "Bearer ";
-    private static final String COOKIE_NAME_REFRESH_TOKEN = "refresh_token";
-
     private final MemberService memberService;
-
-    @PostMapping("/sign-up")
-    public ResponseEntity<ResponseBody<Void>> signUp(@RequestBody @Valid SignUpRequest signUpRequest,
-                                                     HttpServletResponse response) {
-        JwtPair tokens = memberService.signUp(signUpRequest);
-
-        response.addHeader(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + tokens.accessToken());
-
-        Cookie cookie = new Cookie(COOKIE_NAME_REFRESH_TOKEN, tokens.refreshToken());
-        cookie.setHttpOnly(true);
-//        cookie.setSecure(true);
-        cookie.setPath("/tokens/refresh");
-        cookie.setMaxAge(tokens.refreshTokenExpiredIn());
-        response.addCookie(cookie);
-
-        return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
-    }
-
-    @PostMapping("/sign-in")
-    public ResponseEntity<ResponseBody<Void>> signUp(@RequestBody SignInRequest signInRequest,
-                                                     HttpServletResponse response) {
-        JwtPair tokens = memberService.signIn(signInRequest.username(), signInRequest.password());
-
-        response.addHeader(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + tokens.accessToken());
-
-        Cookie cookie = new Cookie(COOKIE_NAME_REFRESH_TOKEN, tokens.refreshToken());
-        cookie.setHttpOnly(true);
-//        cookie.setSecure(true);
-        cookie.setPath("/tokens/refresh");
-        cookie.setMaxAge(tokens.refreshTokenExpiredIn());
-        response.addCookie(cookie);
-
-        return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
-    }
-
-    @DeleteMapping("/sign-out")
-    public ResponseEntity<ResponseBody<Void>> signOut(@AuthenticationPrincipal Long memberId,
-                                                      HttpServletResponse response) {
-        memberService.signOut(memberId);
-
-        return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
-    }
 
     // 사용자의 프로필 정보 반환
     @GetMapping("/{memberId}")


### PR DESCRIPTION
## Reference 🚨
#20 

## What is this PR?🔍
- 기존 각 컨트롤러에서 헤더 추가 및 쿠키를 발급하던 방식에서 하나의 유틸리티성 객체에서 헤더 추가 및 쿠키를 발급하도록 수정합니다.
- 이어지는 PR에서는 MemberController와 MemberService를 용도에 맞게 분리하여 로그인/로그아웃, 기업 사용자, 외국인 사용자로 분리합니다.

## Changes💻
- 각 컨트롤러와 서비스에서 수행하던 헤더 추가 및 쿠키 발급을 `TokenUtilis`에서 수행하도록 변경
- MemberController와 MemberService를 용도별로 분리

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced separate sign-up endpoints for company and foreigner users, each issuing access and refresh tokens upon successful registration.
  - Added dedicated authentication endpoints for user sign-in and sign-out, with token management handled in response headers and cookies.

- **Refactor**
  - Moved sign-up, sign-in, and sign-out endpoints from the general member controller to specialized controllers for improved clarity and organization.

- **Chores**
  - Centralized JWT token handling into a new utility for consistent token management across authentication flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->