### PR TITLE
사용자 컨트롤러 및 서비스 분리 및 성별 매핑 수정

### DIFF
--- a/.github/workflows/dev-cicd-gradle.yml
+++ b/.github/workflows/dev-cicd-gradle.yml
@@ -23,15 +23,6 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
-      postgres:
-        image: postgres:17
-        env:
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
       redis:
         image: redis:alpine
         options: >-

--- a/.github/workflows/dev-cicd-gradle.yml
+++ b/.github/workflows/dev-cicd-gradle.yml
@@ -39,9 +39,6 @@ jobs:
         submodules: true
         token: ${{ secrets.ACTION_TOKEN }} # 조직이 아닌 개인 사용자 토큰이므로 유의할 것!
 
-    # GitHub Actions용 환경 설정
-    - run: touch ./src/main/resources/application-github.yml; echo "${{ secrets.APPLICATION_YML }}" > ./src/main/resources/application-github.yml
-
     # JDK 21 (Eclipse Temurin) 환경 구성
     - name: Set up JDK 21
       uses: actions/setup-java@v4

--- a/.github/workflows/dev-cicd-gradle.yml
+++ b/.github/workflows/dev-cicd-gradle.yml
@@ -25,6 +25,8 @@ jobs:
     services:
       redis:
         image: redis:alpine
+        ports:
+          - 52976:6379
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s

--- a/.github/workflows/dev-cicd-gradle.yml
+++ b/.github/workflows/dev-cicd-gradle.yml
@@ -22,6 +22,24 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
     # 현재 저장소의 소스 코드와 서브 모듈 내려 받기
     - name: Checkout
@@ -29,6 +47,9 @@ jobs:
       with:
         submodules: true
         token: ${{ secrets.ACTION_TOKEN }} # 조직이 아닌 개인 사용자 토큰이므로 유의할 것!
+
+    # GitHub Actions용 환경 설정
+    - run: touch ./src/main/resources/application-github.yml; echo "${{ secrets.APPLICATION_YML }}" > ./src/main/resources/application-github.yml
 
     # JDK 21 (Eclipse Temurin) 환경 구성
     - name: Set up JDK 21
@@ -58,7 +79,7 @@ jobs:
 
     # 빌드 진행
     - name: Build with Gradle
-      run: ./gradlew clean build
+      run: ./gradlew clean build -Pprofile=github
 
     # 빌드 완료 후 아티펙트 업로드 (Actions 탭에서 내려 받기 가능)
     - name: Upload Build Artifacts

--- a/.github/workflows/dev-cicd-gradle.yml
+++ b/.github/workflows/dev-cicd-gradle.yml
@@ -70,7 +70,7 @@ jobs:
 
     # 빌드 진행
     - name: Build with Gradle
-      run: ./gradlew clean build -Pprofile=github
+      run: ./gradlew clean build
 
     # 빌드 완료 후 아티펙트 업로드 (Actions 탭에서 내려 받기 가능)
     - name: Upload Build Artifacts

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'com.h2database:h2'
 
 	// ✅ QueryDSL (Jakarta 기반)
 	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/board/domain/Board.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/board/domain/Board.java
@@ -19,11 +19,9 @@ import java.util.List;
 
 @Entity
 @Table(name = "board")
-@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Board {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -34,6 +32,7 @@ public class Board {
     @Column(name = "description")
     private String description;
 
+    @Builder
     public Board(String name, String description) {
         this.name = name;
         this.description = description;
@@ -44,5 +43,4 @@ public class Board {
 
     @OneToMany(mappedBy = "board", fetch = FetchType.LAZY)
     private List<Post> posts = new ArrayList<>();
-
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/board/domain/Category.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/board/domain/Category.java
@@ -20,11 +20,9 @@ import java.util.List;
 
 @Entity
 @Table(name = "board_category")
-@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Category {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -39,6 +37,7 @@ public class Category {
     @JoinColumn(name = "board_id", nullable = false)
     private Board board;
 
+    @Builder
     public Category(String name, String description, Board board) {
         this.name = name;
         this.description = description;
@@ -47,5 +46,4 @@ public class Category {
 
     @OneToMany(mappedBy = "category", fetch = FetchType.LAZY)
     private List<Post> posts = new ArrayList<>();
-
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/board/domain/Comment.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/board/domain/Comment.java
@@ -19,11 +19,9 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "board_comment")
-@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -48,6 +46,7 @@ public class Comment {
     @Column(name = "published", nullable = false)
     private Boolean published;
 
+    @Builder
     public Comment(String content, Member member, Post post, LocalDateTime createdAt, LocalDateTime updatedAt, Boolean published) {
         this.content = content;
         this.member = member;

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/board/domain/Post.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/board/domain/Post.java
@@ -3,6 +3,7 @@ package kr.ac.kumoh.d138.JobForeigner.board.domain;
 import jakarta.persistence.*;
 import kr.ac.kumoh.d138.JobForeigner.member.domain.Member;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
@@ -13,7 +14,6 @@ import java.util.List;
 @Table(name = "board_post")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_id", nullable = false)
@@ -46,7 +46,7 @@ public class Post {
     @JoinColumn(name = "board_id")  // 외래 키 컬럼명
     private Board board;
 
-
+    @Builder
     public Post(String title, String content, Member member, Category category, LocalDateTime createdAt, LocalDateTime updatedAt, Boolean published) {
         this.title = title;
         this.content = content;
@@ -59,5 +59,4 @@ public class Post {
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Comment> comments = new ArrayList<>();
-
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/exception/ExceptionType.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/exception/ExceptionType.java
@@ -19,6 +19,9 @@ public enum ExceptionType {
     MEMBER_NOT_FOUND(NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
     MEMBER_INFO_INVALID(UNAUTHORIZED, "U002", "아이디 또는 비밀번호가 일치하지 않습니다."),
 
+    // Company
+    COMPANY_NOT_FOUND(NOT_FOUND,"COM001", "회사를 찾을 수 없습니다."),
+
     // Security
     NEED_AUTHORIZED(UNAUTHORIZED, "S001", "인증이 필요합니다."),
     ACCESS_DENIED(FORBIDDEN, "S002", "접근 권한이 없습니다."),

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/exception/ExceptionType.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/exception/ExceptionType.java
@@ -18,6 +18,9 @@ public enum ExceptionType {
     // Member
     MEMBER_NOT_FOUND(NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
     MEMBER_INFO_INVALID(UNAUTHORIZED, "U002", "아이디 또는 비밀번호가 일치하지 않습니다."),
+    USERNAME_ALREADY_EXISTS(CONFLICT, "U003", "이미 등록되어 있거나 사용할 수 없는 아이디입니다."),
+    EMAIL_ALREADY_EXISTS(CONFLICT, "U004", "이미 등록되어 있거나 사용할 수 없는 이메일 주소입니다."),
+    COMPANY_ALREADY_EXISTS(CONFLICT, "U005", "이미 담당자 정보가 등록된 회사입니다."),
 
     // Company
     COMPANY_NOT_FOUND(NOT_FOUND,"COM001", "회사를 찾을 수 없습니다."),

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/controller/MemberController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/controller/MemberController.java
@@ -18,16 +18,16 @@ import static kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil.createS
 public class MemberController {
     private final MemberService memberService;
 
-    // 사용자의 프로필 정보 반환
-    @GetMapping("/{memberId}")
-    public ResponseEntity<ResponseBody<MemberProfileResponse>> getUserProfile(@PathVariable Long memberId) {
-        return ResponseEntity.ok(createSuccessResponse(memberService.getMemberProfile(memberId)));
-    }
-
-    // 자신의 프로필 정보 반환
-    // TODO: 멤버의 아이디를 토큰에서 받아와야함
-    @GetMapping("/me")
-    public ResponseEntity<ResponseBody<MemberProfileResponse>> getMyProfile(Long memberId) {
-        return ResponseEntity.ok(createSuccessResponse(memberService.getMemberProfile(memberId)));
-    }
+//    // 사용자의 프로필 정보 반환
+//    @GetMapping("/{memberId}")
+//    public ResponseEntity<ResponseBody<MemberProfileResponse>> getUserProfile(@PathVariable Long memberId) {
+//        return ResponseEntity.ok(createSuccessResponse(memberService.getMemberProfile(memberId)));
+//    }
+//
+//    // 자신의 프로필 정보 반환
+//    // TODO: 멤버의 아이디를 토큰에서 받아와야함
+//    @GetMapping("/me")
+//    public ResponseEntity<ResponseBody<MemberProfileResponse>> getMyProfile(Long memberId) {
+//        return ResponseEntity.ok(createSuccessResponse(memberService.getMemberProfile(memberId)));
+//    }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/domain/Address.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/domain/Address.java
@@ -14,11 +14,18 @@ import lombok.NoArgsConstructor;
 @Getter
 @EqualsAndHashCode
 public class Address {
-
     private String address;
 
     private String detailAddress;
 
     private String zipcode;
 
+    @Override
+    public String toString() {
+        return "Address{" +
+                "address='" + address + '\'' +
+                ", detailAddress='" + detailAddress + '\'' +
+                ", zipcode='" + zipcode + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/domain/Gender.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/domain/Gender.java
@@ -4,13 +4,21 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
+
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public enum Gender {
-
-    MALE("MALE"),
-    FEMALE("FEMALE");
+    MALE("MALE", 0),
+    FEMALE("FEMALE", 1);
 
     private final String key;
+    private final Integer value;
 
+    public static Gender getGender(final Integer value) {
+        return Arrays.stream(Gender.values())
+                .filter(gender -> gender.getValue().equals(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("성별에 대한 인자는 0(남성), 또는 1(여성) 중 하나여야 합니다."));
+    }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/domain/Gender.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/domain/Gender.java
@@ -9,16 +9,16 @@ import java.util.Arrays;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public enum Gender {
-    MALE("MALE", 0),
-    FEMALE("FEMALE", 1);
+    MALE("MALE", 'M'),
+    FEMALE("FEMALE", 'F');
 
     private final String key;
-    private final Integer value;
+    private final Character value;
 
-    public static Gender getGender(final Integer value) {
+    public static Gender getGender(final Character value) {
         return Arrays.stream(Gender.values())
                 .filter(gender -> gender.getValue().equals(value))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("성별에 대한 인자는 0(남성), 또는 1(여성) 중 하나여야 합니다."));
+                .orElseThrow(() -> new IllegalArgumentException("성별에 대한 인자는 'M'(남성), 또는 'F'(여성) 중 하나여야 합니다."));
     }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/domain/GenderConverter.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/domain/GenderConverter.java
@@ -1,0 +1,17 @@
+package kr.ac.kumoh.d138.JobForeigner.member.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class GenderConverter implements AttributeConverter<Gender, Integer> {
+    @Override
+    public Integer convertToDatabaseColumn(Gender attribute) {
+        return attribute.getValue();
+    }
+
+    @Override
+    public Gender convertToEntityAttribute(Integer dbData) {
+        return Gender.getGender(dbData);
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/domain/GenderConverter.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/domain/GenderConverter.java
@@ -4,14 +4,14 @@ import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 
 @Converter
-public class GenderConverter implements AttributeConverter<Gender, Integer> {
+public class GenderConverter implements AttributeConverter<Gender, Character> {
     @Override
-    public Integer convertToDatabaseColumn(Gender attribute) {
+    public Character convertToDatabaseColumn(Gender attribute) {
         return attribute.getValue();
     }
 
     @Override
-    public Gender convertToEntityAttribute(Integer dbData) {
-        return Gender.getGender(dbData);
+    public Gender convertToEntityAttribute(Character dbData) {
+        return dbData != null ? Gender.getGender(dbData) : null;
     }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/domain/Member.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/domain/Member.java
@@ -3,6 +3,7 @@ package kr.ac.kumoh.d138.JobForeigner.member.domain;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -15,12 +16,15 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import kr.ac.kumoh.d138.JobForeigner.board.domain.Comment;
 import kr.ac.kumoh.d138.JobForeigner.board.domain.Post;
+import kr.ac.kumoh.d138.JobForeigner.global.base.BaseEntity;
 import kr.ac.kumoh.d138.JobForeigner.rating.Rating;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -30,8 +34,9 @@ import java.util.List;
 @Table(name = "member")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
-
+@SQLDelete(sql = "UPDATE member SET deleted_at = NOW() where id = ?")
+@SQLRestriction(value = "deleted_at is NULL") // TODO: 7일 후 논리적 삭제된 사용자를 물리적으로 삭제하는 cron 작업이 필요
+public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id", nullable = false)
@@ -50,6 +55,9 @@ public class Member {
     @Column(name = "type", nullable = false)
     private MemberType type;
 
+    @Column(name = "comany_id")
+    private Long companyId;
+
     @Column(name = "country_code")
     private String countryCode;
 
@@ -59,8 +67,8 @@ public class Member {
     @Column(name = "email", nullable = false, unique = true)
     private String email;
 
-    @Enumerated(value = EnumType.STRING)
-    @Column(name = "gender", nullable = false)
+    @Convert(converter = GenderConverter.class)
+    @Column(name = "gender", columnDefinition = "smallint", nullable = false)
     private Gender gender;
 
     @Column(name = "birth_date", nullable = false)
@@ -83,6 +91,7 @@ public class Member {
             @NonNull String username,
             @NonNull String password,
             @NonNull MemberType type,
+            Long companyId,
             String countryCode,
             @NonNull String phoneNumber,
             @NonNull String email,
@@ -95,6 +104,7 @@ public class Member {
         this.username = username;
         this.password = password;
         this.type = type;
+        this.companyId = companyId;
         this.countryCode = countryCode;
         this.phoneNumber = phoneNumber;
         this.email = email;
@@ -112,4 +122,22 @@ public class Member {
 
     @OneToMany(mappedBy="member", fetch=FetchType.LAZY)
     private List<Rating> ratings = new ArrayList<>();
+
+    @Override
+    public String toString() {
+        return "Member{" +
+                "address=" + address +
+                ", profileImageUrl='" + profileImageUrl + '\'' +
+                ", birthDate=" + birthDate +
+                ", gender=" + gender +
+                ", email='" + email + '\'' +
+                ", phoneNumber='" + phoneNumber + '\'' +
+                ", countryCode='" + countryCode + '\'' +
+                ", type=" + type +
+                ", password='" + password + '\'' +
+                ", username='" + username + '\'' +
+                ", name='" + name + '\'' +
+                ", id=" + id +
+                '}';
+    }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/domain/Member.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/domain/Member.java
@@ -55,7 +55,7 @@ public class Member extends BaseEntity {
     @Column(name = "type", nullable = false)
     private MemberType type;
 
-    @Column(name = "comany_id")
+    @Column(name = "company_id")
     private Long companyId;
 
     @Column(name = "country_code")
@@ -68,7 +68,7 @@ public class Member extends BaseEntity {
     private String email;
 
     @Convert(converter = GenderConverter.class)
-    @Column(name = "gender", columnDefinition = "smallint", nullable = false)
+    @Column(name = "gender", columnDefinition = "char(1)", nullable = false)
     private Gender gender;
 
     @Column(name = "birth_date", nullable = false)
@@ -80,7 +80,7 @@ public class Member extends BaseEntity {
     @Embedded
     @AttributeOverrides({
             @AttributeOverride(name = "address", column = @Column(name = "address", nullable = false)),
-            @AttributeOverride(name = "detailAddress", column = @Column(name = "detail_address", nullable = false)),
+            @AttributeOverride(name = "detailAddress", column = @Column(name = "detail_address")),
             @AttributeOverride(name = "zipcode", column = @Column(name = "zipcode", nullable = false))
     })
     private Address address;
@@ -122,22 +122,4 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy="member", fetch=FetchType.LAZY)
     private List<Rating> ratings = new ArrayList<>();
-
-    @Override
-    public String toString() {
-        return "Member{" +
-                "address=" + address +
-                ", profileImageUrl='" + profileImageUrl + '\'' +
-                ", birthDate=" + birthDate +
-                ", gender=" + gender +
-                ", email='" + email + '\'' +
-                ", phoneNumber='" + phoneNumber + '\'' +
-                ", countryCode='" + countryCode + '\'' +
-                ", type=" + type +
-                ", password='" + password + '\'' +
-                ", username='" + username + '\'' +
-                ", name='" + name + '\'' +
-                ", id=" + id +
-                '}';
-    }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/SignUpForCompanyRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/SignUpForCompanyRequest.java
@@ -1,15 +1,13 @@
 package kr.ac.kumoh.d138.JobForeigner.member.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-
 import java.time.LocalDate;
 
-public record SignUpRequest(
+public record SignUpForCompanyRequest(
         String name,
         String username,
         String password,
         String type,
+        Long companyId,
         String phoneNumber,
         String email,
         String gender,

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/SignUpForCompanyRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/SignUpForCompanyRequest.java
@@ -1,20 +1,38 @@
 package kr.ac.kumoh.d138.JobForeigner.member.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
 import java.time.LocalDate;
 
 public record SignUpForCompanyRequest(
+        @NotBlank(message = "담당자 이름은 필수 입력 항목입니다.")
         String name,
+        @NotBlank(message = "기업 계정 아이디는 필수 입력 항목입니다.")
         String username,
+        @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+        @Pattern(regexp = "^[\\x20-\\x7E]{8,}$", message = "8자 이상의 알파벳 대소문자, 숫자, 특수문자만 사용할 수 있습니다.")
         String password,
+        @NotBlank(message = "사용자 유형은 필수 입력 항목입니다.")
         String type,
+        @NotNull(message = "기업 아이디는 필수 입력 항목입니다.")
         Long companyId,
+        @NotBlank(message = "담당자 전화번호는 필수 입력 항목입니다.")
         String phoneNumber,
+        @NotBlank(message = "담당자 이메일은 필수 입력 항목입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
         String email,
+        @NotBlank(message = "담당자 성별은 필수 입력 항목입니다.")
         String gender,
+        @NotNull(message = "담당자 생년월일은 필수 입력 항목입니다.")
         LocalDate birthDate,
         String profileImageUrl,
+        @NotBlank(message = "기업 주소는 필수 입력 항목입니다.")
         String address,
         String detailAddress,
+        @NotBlank(message = "기업 우편번호는 필수 입력 항목입니다.")
         String zipcode
 ) {
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/SignUpForCompanyRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/SignUpForCompanyRequest.java
@@ -25,6 +25,7 @@ public record SignUpForCompanyRequest(
         @Email(message = "올바른 이메일 형식이 아닙니다.")
         String email,
         @NotBlank(message = "담당자 성별은 필수 입력 항목입니다.")
+        @Pattern(regexp = "MALE|FEMALE", message = "성별은 MALE 또는 FEMALE이어야 합니다.")
         String gender,
         @NotNull(message = "담당자 생년월일은 필수 입력 항목입니다.")
         LocalDate birthDate,

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/SignUpForForeignerRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/SignUpForForeignerRequest.java
@@ -1,19 +1,36 @@
 package kr.ac.kumoh.d138.JobForeigner.member.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
 import java.time.LocalDate;
 
 public record SignUpForForeignerRequest(
+        @NotBlank(message = "이름은 필수 입력 항목입니다.")
         String name,
+        @NotBlank(message = "아이디는 필수 입력 항목입니다.")
         String username,
+        @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+        @Pattern(regexp = "^[\\x20-\\x7E]{8,}$", message = "8자 이상의 알파벳 대소문자, 숫자, 특수문자만 사용할 수 있습니다.")
         String password,
+        @NotBlank(message = "사용자 유형은 필수 입력 항목입니다.")
         String type,
+        @NotBlank(message = "전화번호는 필수 입력 항목입니다.")
         String phoneNumber,
+        @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
         String email,
+        @NotBlank(message = "성별은 필수 입력 항목입니다.")
         String gender,
+        @NotNull(message = "생년월일은 필수 입력 항목입니다.")
         LocalDate birthDate,
         String profileImageUrl,
+        @NotBlank(message = "주소는 필수 입력 항목입니다.")
         String address,
         String detailAddress,
+        @NotBlank(message = "우편번호는 필수 입력 항목입니다.")
         String zipcode
 ) {
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/SignUpForForeignerRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/SignUpForForeignerRequest.java
@@ -1,0 +1,19 @@
+package kr.ac.kumoh.d138.JobForeigner.member.dto.request;
+
+import java.time.LocalDate;
+
+public record SignUpForForeignerRequest(
+        String name,
+        String username,
+        String password,
+        String type,
+        String phoneNumber,
+        String email,
+        String gender,
+        LocalDate birthDate,
+        String profileImageUrl,
+        String address,
+        String detailAddress,
+        String zipcode
+) {
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/SignUpForForeignerRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/SignUpForForeignerRequest.java
@@ -23,6 +23,7 @@ public record SignUpForForeignerRequest(
         @Email(message = "올바른 이메일 형식이 아닙니다.")
         String email,
         @NotBlank(message = "성별은 필수 입력 항목입니다.")
+        @Pattern(regexp = "MALE|FEMALE", message = "성별은 MALE 또는 FEMALE이어야 합니다.")
         String gender,
         @NotNull(message = "생년월일은 필수 입력 항목입니다.")
         LocalDate birthDate,

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/repository/MemberRepository.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/repository/MemberRepository.java
@@ -7,4 +7,12 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUsername(String username);
+    boolean existsByUsername(String username);
+
+    Optional<Member> findByEmail(String email);
+    boolean existsByEmail(String email);
+
+    Optional<Member> findByCompanyId(Long companyId);
+    boolean existsByCompanyId(Long companyId);
+
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/AuthService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/AuthService.java
@@ -1,0 +1,60 @@
+package kr.ac.kumoh.d138.JobForeigner.member.service;
+
+import kr.ac.kumoh.d138.JobForeigner.global.exception.BusinessException;
+import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.JwtClaims;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.access.AccessTokenData;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.access.AccessTokenProvider;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.refresh.RefreshTokenData;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.refresh.RefreshTokenProvider;
+import kr.ac.kumoh.d138.JobForeigner.member.domain.Member;
+import kr.ac.kumoh.d138.JobForeigner.member.repository.MemberRepository;
+import kr.ac.kumoh.d138.JobForeigner.token.domain.RefreshToken;
+import kr.ac.kumoh.d138.JobForeigner.token.domain.RefreshTokenRepository;
+import kr.ac.kumoh.d138.JobForeigner.token.dto.JwtPair;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    private final AccessTokenProvider accessTokenProvider;
+    private final RefreshTokenProvider refreshTokenProvider;
+
+    private final PasswordEncoder passwordEncoder;
+
+    public JwtPair signIn(String username, String password) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new BusinessException(ExceptionType.MEMBER_NOT_FOUND));
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(password, member.getPassword())) {
+            throw new BusinessException(ExceptionType.MEMBER_INFO_INVALID);
+        }
+
+        log.info("로그인이 완료되었습니다. {}", member);
+
+        // 토큰 발급
+        JwtClaims claims = JwtClaims.create(member);
+        AccessTokenData accessToken = accessTokenProvider.createToken(claims);
+        RefreshTokenData refreshToken = refreshTokenProvider.createToken(claims);
+
+        refreshTokenRepository.save(RefreshToken.from(refreshToken));
+
+        log.debug("로그인 후 토큰이 발행되었습니다. {}, {}", accessToken, refreshToken);
+
+        return JwtPair.of(accessToken.token(), accessToken.expiredIn(), refreshToken.token(), refreshToken.expiredIn());
+    }
+
+    public void signOut(Long memberId) {
+        refreshTokenRepository.deleteById(memberId);
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/AuthService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/AuthService.java
@@ -40,21 +40,21 @@ public class AuthService {
             throw new BusinessException(ExceptionType.MEMBER_INFO_INVALID);
         }
 
-        log.info("로그인이 완료되었습니다. {}", member);
-
         // 토큰 발급
+        return generateJwtPair(member);
+    }
+
+    public void signOut(Long memberId) {
+        refreshTokenRepository.deleteById(memberId);
+    }
+
+    public JwtPair generateJwtPair(Member member) {
         JwtClaims claims = JwtClaims.create(member);
         AccessTokenData accessToken = accessTokenProvider.createToken(claims);
         RefreshTokenData refreshToken = refreshTokenProvider.createToken(claims);
 
         refreshTokenRepository.save(RefreshToken.from(refreshToken));
 
-        log.debug("로그인 후 토큰이 발행되었습니다. {}, {}", accessToken, refreshToken);
-
         return JwtPair.of(accessToken.token(), accessToken.expiredIn(), refreshToken.token(), refreshToken.expiredIn());
-    }
-
-    public void signOut(Long memberId) {
-        refreshTokenRepository.deleteById(memberId);
     }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/CompanyMemberService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/CompanyMemberService.java
@@ -1,0 +1,78 @@
+package kr.ac.kumoh.d138.JobForeigner.member.service;
+
+import kr.ac.kumoh.d138.JobForeigner.global.exception.BusinessException;
+import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.JwtClaims;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.access.AccessTokenData;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.access.AccessTokenProvider;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.refresh.RefreshTokenData;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.refresh.RefreshTokenProvider;
+import kr.ac.kumoh.d138.JobForeigner.job.domain.repository.CompanyRepository;
+import kr.ac.kumoh.d138.JobForeigner.member.domain.Address;
+import kr.ac.kumoh.d138.JobForeigner.member.domain.Gender;
+import kr.ac.kumoh.d138.JobForeigner.member.domain.Member;
+import kr.ac.kumoh.d138.JobForeigner.member.domain.MemberType;
+import kr.ac.kumoh.d138.JobForeigner.member.dto.request.SignUpForCompanyRequest;
+import kr.ac.kumoh.d138.JobForeigner.member.repository.MemberRepository;
+import kr.ac.kumoh.d138.JobForeigner.token.domain.RefreshToken;
+import kr.ac.kumoh.d138.JobForeigner.token.domain.RefreshTokenRepository;
+import kr.ac.kumoh.d138.JobForeigner.token.dto.JwtPair;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.service.spi.ServiceException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class CompanyMemberService {
+
+    private final MemberRepository memberRepository;
+    private final CompanyRepository companyRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    private final AccessTokenProvider accessTokenProvider;
+    private final RefreshTokenProvider refreshTokenProvider;
+
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public JwtPair signUp(SignUpForCompanyRequest req) {
+        if (!companyRepository.existsById(req.companyId())) {
+            throw new BusinessException(ExceptionType.COMPANY_NOT_FOUND);
+        }
+
+        Member member = Member.builder()
+                .name(req.name())
+                .username(req.username())
+                .password(passwordEncoder.encode(req.password()))
+                .type(MemberType.valueOf(req.type()))
+                .companyId(req.companyId())
+                .phoneNumber(req.phoneNumber())
+                .email(req.email())
+                .gender(Gender.valueOf(req.gender()))
+                .birthDate(req.birthDate())
+                .profileImageUrl(req.profileImageUrl())
+                .address(new Address(req.address(), req.detailAddress(), req.zipcode()))
+                .build();
+
+        memberRepository.save(member);
+
+        log.info("기업 사용자 회원가입이 완료되었습니다. {}", member);
+
+        // 토큰 발급
+        JwtClaims claims = JwtClaims.create(member);
+        AccessTokenData accessToken = accessTokenProvider.createToken(claims);
+        RefreshTokenData refreshToken = refreshTokenProvider.createToken(claims);
+
+        refreshTokenRepository.save(RefreshToken.from(refreshToken));
+
+        log.debug("기업 사용자 회원가입 후 토큰이 발행되었습니다. {}, {}", accessToken, refreshToken);
+
+        return JwtPair.of(accessToken.token(), accessToken.expiredIn(), refreshToken.token(), refreshToken.expiredIn());
+    }
+
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/CompanyMemberService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/CompanyMemberService.java
@@ -7,7 +7,7 @@ import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.access.AccessTokenData;
 import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.access.AccessTokenProvider;
 import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.refresh.RefreshTokenData;
 import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.refresh.RefreshTokenProvider;
-import kr.ac.kumoh.d138.JobForeigner.job.domain.repository.CompanyRepository;
+import kr.ac.kumoh.d138.JobForeigner.job.repository.CompanyRepository;
 import kr.ac.kumoh.d138.JobForeigner.member.domain.Address;
 import kr.ac.kumoh.d138.JobForeigner.member.domain.Gender;
 import kr.ac.kumoh.d138.JobForeigner.member.domain.Member;

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/ForeignerMemberService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/ForeignerMemberService.java
@@ -1,18 +1,13 @@
 package kr.ac.kumoh.d138.JobForeigner.member.service;
 
-import kr.ac.kumoh.d138.JobForeigner.global.jwt.JwtClaims;
-import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.access.AccessTokenData;
-import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.access.AccessTokenProvider;
-import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.refresh.RefreshTokenData;
-import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.refresh.RefreshTokenProvider;
+import kr.ac.kumoh.d138.JobForeigner.global.exception.BusinessException;
+import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
 import kr.ac.kumoh.d138.JobForeigner.member.domain.Address;
 import kr.ac.kumoh.d138.JobForeigner.member.domain.Gender;
 import kr.ac.kumoh.d138.JobForeigner.member.domain.Member;
 import kr.ac.kumoh.d138.JobForeigner.member.domain.MemberType;
 import kr.ac.kumoh.d138.JobForeigner.member.dto.request.SignUpForForeignerRequest;
 import kr.ac.kumoh.d138.JobForeigner.member.repository.MemberRepository;
-import kr.ac.kumoh.d138.JobForeigner.token.domain.RefreshToken;
-import kr.ac.kumoh.d138.JobForeigner.token.domain.RefreshTokenRepository;
 import kr.ac.kumoh.d138.JobForeigner.token.dto.JwtPair;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,15 +22,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class ForeignerMemberService {
 
     private final MemberRepository memberRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
 
-    private final AccessTokenProvider accessTokenProvider;
-    private final RefreshTokenProvider refreshTokenProvider;
+    private final AuthService authService;
 
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public JwtPair signUp(SignUpForForeignerRequest req) {
+        if (memberRepository.existsByUsername(req.username())) {
+            throw new BusinessException(ExceptionType.USERNAME_ALREADY_EXISTS);
+        }
+        if (memberRepository.existsByEmail(req.email())) {
+            throw new BusinessException(ExceptionType.EMAIL_ALREADY_EXISTS);
+        }
+
         Member member = Member.builder()
                 .name(req.name())
                 .username(req.username())
@@ -51,18 +51,8 @@ public class ForeignerMemberService {
 
         memberRepository.save(member);
 
-        log.info("외국인 사용자 회원가입이 완료되었습니다. {}", member);
-
         // 토큰 발급
-        JwtClaims claims = JwtClaims.create(member);
-        AccessTokenData accessToken = accessTokenProvider.createToken(claims);
-        RefreshTokenData refreshToken = refreshTokenProvider.createToken(claims);
-
-        refreshTokenRepository.save(RefreshToken.from(refreshToken));
-
-        log.debug("외국인 사용자 회원가입 후 토큰이 발행되었습니다. {}, {}", accessToken, refreshToken);
-
-        return JwtPair.of(accessToken.token(), accessToken.expiredIn(), refreshToken.token(), refreshToken.expiredIn());
+        return authService.generateJwtPair(member);
     }
 
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/ForeignerMemberService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/ForeignerMemberService.java
@@ -1,0 +1,68 @@
+package kr.ac.kumoh.d138.JobForeigner.member.service;
+
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.JwtClaims;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.access.AccessTokenData;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.access.AccessTokenProvider;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.refresh.RefreshTokenData;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.refresh.RefreshTokenProvider;
+import kr.ac.kumoh.d138.JobForeigner.member.domain.Address;
+import kr.ac.kumoh.d138.JobForeigner.member.domain.Gender;
+import kr.ac.kumoh.d138.JobForeigner.member.domain.Member;
+import kr.ac.kumoh.d138.JobForeigner.member.domain.MemberType;
+import kr.ac.kumoh.d138.JobForeigner.member.dto.request.SignUpForForeignerRequest;
+import kr.ac.kumoh.d138.JobForeigner.member.repository.MemberRepository;
+import kr.ac.kumoh.d138.JobForeigner.token.domain.RefreshToken;
+import kr.ac.kumoh.d138.JobForeigner.token.domain.RefreshTokenRepository;
+import kr.ac.kumoh.d138.JobForeigner.token.dto.JwtPair;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class ForeignerMemberService {
+
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    private final AccessTokenProvider accessTokenProvider;
+    private final RefreshTokenProvider refreshTokenProvider;
+
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public JwtPair signUp(SignUpForForeignerRequest req) {
+        Member member = Member.builder()
+                .name(req.name())
+                .username(req.username())
+                .password(passwordEncoder.encode(req.password()))
+                .type(MemberType.valueOf(req.type()))
+                .phoneNumber(req.phoneNumber())
+                .email(req.email())
+                .gender(Gender.valueOf(req.gender()))
+                .birthDate(req.birthDate())
+                .profileImageUrl(req.profileImageUrl())
+                .address(new Address(req.address(), req.detailAddress(), req.zipcode()))
+                .build();
+
+        memberRepository.save(member);
+
+        log.info("외국인 사용자 회원가입이 완료되었습니다. {}", member);
+
+        // 토큰 발급
+        JwtClaims claims = JwtClaims.create(member);
+        AccessTokenData accessToken = accessTokenProvider.createToken(claims);
+        RefreshTokenData refreshToken = refreshTokenProvider.createToken(claims);
+
+        refreshTokenRepository.save(RefreshToken.from(refreshToken));
+
+        log.debug("외국인 사용자 회원가입 후 토큰이 발행되었습니다. {}, {}", accessToken, refreshToken);
+
+        return JwtPair.of(accessToken.token(), accessToken.expiredIn(), refreshToken.token(), refreshToken.expiredIn());
+    }
+
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/MemberService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/MemberService.java
@@ -1,5 +1,8 @@
 package kr.ac.kumoh.d138.JobForeigner.member.service;
 
+import kr.ac.kumoh.d138.JobForeigner.global.exception.BusinessException;
+import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
+import kr.ac.kumoh.d138.JobForeigner.member.domain.Member;
 import kr.ac.kumoh.d138.JobForeigner.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/MemberService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/MemberService.java
@@ -2,26 +2,11 @@ package kr.ac.kumoh.d138.JobForeigner.member.service;
 
 import kr.ac.kumoh.d138.JobForeigner.global.exception.BusinessException;
 import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
-import kr.ac.kumoh.d138.JobForeigner.global.jwt.JwtClaims;
-import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.access.AccessTokenData;
-import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.access.AccessTokenProvider;
-import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.refresh.RefreshTokenData;
-import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.refresh.RefreshTokenProvider;
-import kr.ac.kumoh.d138.JobForeigner.member.domain.Address;
-import kr.ac.kumoh.d138.JobForeigner.member.domain.Gender;
 import kr.ac.kumoh.d138.JobForeigner.member.domain.Member;
-import kr.ac.kumoh.d138.JobForeigner.member.domain.MemberType;
-import kr.ac.kumoh.d138.JobForeigner.member.dto.request.MemberProfileRequest;
-import kr.ac.kumoh.d138.JobForeigner.member.dto.request.ProfileImageRequest;
-import kr.ac.kumoh.d138.JobForeigner.member.dto.request.SignUpRequest;
 import kr.ac.kumoh.d138.JobForeigner.member.dto.response.MemberProfileResponse;
 import kr.ac.kumoh.d138.JobForeigner.member.repository.MemberRepository;
-import kr.ac.kumoh.d138.JobForeigner.token.domain.RefreshToken;
-import kr.ac.kumoh.d138.JobForeigner.token.domain.RefreshTokenRepository;
-import kr.ac.kumoh.d138.JobForeigner.token.dto.JwtPair;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,64 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 public class MemberService {
-
     private final MemberRepository memberRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
-
-    private final AccessTokenProvider accessTokenProvider;
-    private final RefreshTokenProvider refreshTokenProvider;
-
-    private final PasswordEncoder passwordEncoder;
-
-    @Transactional
-    public JwtPair signUp (SignUpRequest req) {
-        Member member = Member.builder()
-                .name(req.name())
-                .username(req.username())
-                .password(passwordEncoder.encode(req.password()))
-                .type(MemberType.valueOf(req.type()))
-                .phoneNumber(req.phoneNumber())
-                .email(req.email())
-                .gender(Gender.valueOf(req.gender()))
-                .birthDate(req.birthDate())
-                .profileImageUrl(req.profileImageUrl())
-                .address(new Address(req.address(), req.detailAddress(), req.zipcode()))
-                .build();
-
-        memberRepository.save(member);
-
-        // 토큰 발급
-        JwtClaims claims = JwtClaims.create(member);
-        AccessTokenData accessToken = accessTokenProvider.createToken(claims);
-        RefreshTokenData refreshToken = refreshTokenProvider.createToken(claims);
-
-        refreshTokenRepository.save(RefreshToken.from(refreshToken));
-
-        return JwtPair.of(accessToken.token(), accessToken.expiredIn(), refreshToken.token(), refreshToken.expiredIn());
-    }
-
-    public JwtPair signIn (String username, String password) {
-        Member member = memberRepository.findByUsername(username)
-                .orElseThrow(() -> new BusinessException(ExceptionType.MEMBER_NOT_FOUND));
-
-        // 비밀번호 검증
-        if (!passwordEncoder.matches(password, member.getPassword())) {
-            throw new BusinessException(ExceptionType.MEMBER_INFO_INVALID);
-        }
-
-        // 토큰 발급
-        JwtClaims claims = JwtClaims.create(member);
-        AccessTokenData accessToken = accessTokenProvider.createToken(claims);
-        RefreshTokenData refreshToken = refreshTokenProvider.createToken(claims);
-
-        refreshTokenRepository.save(RefreshToken.from(refreshToken));
-
-        return JwtPair.of(accessToken.token(), accessToken.expiredIn(), refreshToken.token(), refreshToken.expiredIn());
-    }
-
-    public void signOut(Long memberId) {
-        refreshTokenRepository.deleteById(memberId);
-    }
 
     public MemberProfileResponse getMemberProfile(Long memberId) {
         Member member = memberRepository.findById(memberId)
@@ -106,5 +34,4 @@ public class MemberService {
     public void updateProfileImage(ProfileImageRequest request, Long memberId) {
 
     }
-
 }

--- a/src/test/java/kr/ac/kumoh/d138/JobForeigner/JobForeignerApplicationTests.java
+++ b/src/test/java/kr/ac/kumoh/d138/JobForeigner/JobForeignerApplicationTests.java
@@ -2,8 +2,10 @@ package kr.ac.kumoh.d138.JobForeigner;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class JobForeignerApplicationTests {
 
 	@Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -13,7 +13,7 @@ spring:
   data:
     redis:
       host: localhost
-      port: 6379
+      port: 52976
 
 logging:
   level:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,35 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;CASE_INSENSITIVE_IDENTIFIERS=true;DB_CLOSE_DELAY=-1
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+logging:
+  level:
+    org.springframework.web.servlet: debug
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace
+    org.hibernate.orm.jdb.extract: trace
+    org.hibernate.type.descriptor.sql: trace
+
+cryptographic-key:
+  publicKeyPath: "./src/main/resources/properties/cryptographic_key/public_key_test.pem"
+  privateKeyPath: "./src/main/resources/properties/cryptographic_key/private_key_test.pem"
+  salt: "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567"
+
+jwt:
+  issuer: "JobForeigner"
+  audience: "JobForeigner"
+  accessTokenExpiredIn: 1800
+  refreshTokenExpiredIn: 1209600


### PR DESCRIPTION
## What is this PR?🔍
**사용자 컨트롤러 및 서비스 분리**
- 외국인 사용자와 기업 사용자를 한 곳에서 관리하지 않고 분리해 관리합니다.(`ForeignerMemberService`와 `ForeignerMemberController`, `CompanyMemberService`와 `CompanyMemberController`)
두 사용자가 중복된 기능을 가지지 않도록 `MemberController`와 `MemberService`에서 중복 기능을 처리합니다.

**성별 매핑 수정**
- 기존 STRING으로 성별을 저장(`MALE`과 `FEMALE`)하던 방식에서 SMALLINT로 성별을 저장(`0`과 `1`)하는 방식으로 변경합니다.
  - TINYINT로 하지 않은 이유는 MySQL에만 존재하는 타입이며, Boolean으로 하지 않은 이유는 MySQL에 존재하지 않는 타입이기 때문입니다.
  - 프론트엔드에서 요청을 보내는 JSON은 문자열(`MALE`과 `FEMALE`)을 백엔드로 넘깁니다.

**임시 주석 처리**
- 사용자 프로필과 관련한 DTO와 도메인 로직이 존재하지 않아 서비스와 컨트롤러의 메서드를 주석 처리했습니다. 양해 부탁드립니다.

## Changes💻
- `MemberService`와 `MemberController`에서 외국인 사용자와 기업 사용자를 처리하던 방식에서 `ForeignerMemberService`와 `ForeignerMemberController`, `CompanyMemberService`와 `CompanyMemberController`를 만들어 각 클래스에서 처리하도록 합니다.
- Member 엔티티 Gender 애트리뷰트의 데이터베이스 매핑 방식을 문자열에서 정수로 변경합니다.

## ScreenShot📷
> 데이터베이스에 문자형(`CHAR(1)`)로 잘 저장되었습니다.
![image](https://github.com/user-attachments/assets/e7ffaaf6-f14a-4af4-9ca6-0eb2b5e7e431)

#20 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **신규 기능**
    - 외국인 및 기업 회원 가입을 위한 별도의 서비스와 요청 양식이 추가되었습니다.
    - 회원 인증(로그인/로그아웃) 기능이 별도의 서비스로 분리되어 제공됩니다.
- **변경 사항**
    - 회원 정보 및 프로필 조회 관련 기존 엔드포인트가 비활성화되었습니다.
    - 회원 엔티티에 회사 ID, 논리적 삭제 기능, 성별 변환 및 표시 개선이 적용되었습니다.
    - 게시판 관련 도메인 클래스에 빌더 패턴 적용 범위가 생성자 단위로 조정되었습니다.
    - CI/CD 워크플로우에 Redis 서비스 컨테이너가 추가되고, 빌드 프로필 설정이 반영되었습니다.
    - 회원 저장소에 사용자명, 이메일, 회사 ID 기반 조회 및 중복 검사 기능이 추가되었습니다.
    - 예외 처리에 사용자명, 이메일, 회사 중복 관련 새로운 예외 타입이 추가되었습니다.
- **버그 수정**
    - 회원 엔티티의 회사 ID 컬럼명 오타가 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->