### PR TITLE
[DOCS] QueryDSL 라이브러리 변경 및 버전 업데이트

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,16 +1,17 @@
-language: ko-KR # 언어 설정
+language: ko-KR
 
-early_access: true # 미리보기 기능 활성화
-enable_free_tier: true # 프리 티어 활성화
-auto_resolve_threads: false # 자동 해결 비활성화
+early_access: true
+enable_free_tier: true
 
 reviews:
   profile: chill
   request_changes_workflow: true
   high_level_summary: true
-  high_level_summary_placeholder: '@coderabbitai 요약'
+  high_level_summary_placeholder: '@coderabbitai summary'
   auto_title_placeholder: '@coderabbitai'
-  poem: true
+  sequence_diagrams: true
+  suggested_reviewers: false
+  poem: false
   review_status: true
   collapse_walkthrough: false
 
@@ -94,8 +95,7 @@ reviews:
       essential_rules: true
 
 chat:
-  enabled: true
-  max_token_length: 4096
+  auto_reply: true
 
 knowledge_base:
   web_search:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.1'
+	id 'org.springframework.boot' version '3.4.5'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -51,11 +51,10 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testRuntimeOnly 'com.h2database:h2'
 
-	// ✅ QueryDSL (Jakarta 기반)
-	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
-	annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
-	annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1'
-	annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+	// QueryDSL
+	implementation 'io.github.openfeign.querydsl:querydsl-core:6.11'
+	implementation 'io.github.openfeign.querydsl:querydsl-jpa:6.11'
+	annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.11:jpa'
 
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
@@ -65,19 +64,20 @@ tasks.named('test') {
 	useJUnitPlatform()
 }
 
-// ✅ QueryDSL QClass 생성 설정 (Gradle 8+ 최신 방식)
+// QueryDSL QClass 생성 위치 설정
 def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
 
-sourceSets {
-	main {
-		java {
-			srcDirs += querydslDir
-		}
-	}
-}
-
+// 컴파일 시 설정한 위치에 QClass가 생성되도록 설정
 tasks.withType(JavaCompile).configureEach {
 	options.generatedSourceOutputDirectory = querydslDir
 }
 
+// QClass 생성 위치를 클래스패스에 추가
+sourceSets {
+	main.java.srcDirs += [ querydslDir ]
+}
 
+// gradlew clean 명령 시 QueryDSL QClass 삭제
+clean {
+	delete querydslDir
+}


### PR DESCRIPTION
## What is this PR?🔍
현재 사용 중인 QueryDSL 라이브러리에 보안 취약점[(CVE-2024-49203)](https://nvd.nist.gov/vuln/detail/CVE-2024-49203)이 존재함에 따라 이를 새로운 라이브러리로 변경합니다. 이 라이브러리는 [스프링 공식 문서](https://docs.spring.io/spring-data/jpa/reference/repositories/core-extensions.html)에서 소개되고 있습니다.

추가로 Spring Boot 버전을 업데이트하며 dependabot, coderabbit 설정을 추가 및 수정합니다.

## Changes💻
- QueryDSL 포크 라이브러리로 수정
- Spring Boot 버전 업데이트
- dependabot 설정 추가
- coderabbit 설정 수정

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - Gradle 및 GitHub Actions의 의존성 자동 업데이트를 위한 구성 파일이 추가되었습니다.

- **버그 수정**
  - QueryDSL 의존성이 최신 버전으로 교체되고, 빌드 및 소스 생성 디렉터리 관리가 개선되었습니다.

- **문서화**
  - 리뷰 및 채팅 설정 관련 구성 파일이 업데이트되어 일부 옵션이 변경 및 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->