### PR TITLE
이력서 생성/수정/조회 로직 추가

### DIFF
--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/exception/ExceptionType.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/exception/ExceptionType.java
@@ -41,7 +41,7 @@ public enum ExceptionType {
 
     // Resume
     RESUME_FORBIDDEN(FORBIDDEN,"R001","접근할 수 없는 이력서입니다."),
-    RESUME_NOT_FOUND(NOT_FOUND, "ROO2", "존재하지 않는 이력서입니다.")
+    RESUME_NOT_FOUND(NOT_FOUND, "R002", "존재하지 않는 이력서입니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/exception/ExceptionType.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/exception/ExceptionType.java
@@ -39,6 +39,9 @@ public enum ExceptionType {
     JWT_INVALID(UNAUTHORIZED, "S004", "인증 정보가 잘못되었습니다."),
     JWT_NOT_EXIST(UNAUTHORIZED, "S005", "인증 정보가 존재하지 않습니다."),
 
+    // Resume
+    RESUME_FORBIDDEN(FORBIDDEN,"R001","접근할 수 없는 이력서입니다."),
+    RESUME_NOT_FOUND(NOT_FOUND, "ROO2", "존재하지 않는 이력서입니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/controller/ResumeController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/controller/ResumeController.java
@@ -82,5 +82,11 @@ public class ResumeController {
         return ResponseEntity.ok(createSuccessResponse());
     }
 
+    @DeleteMapping("/{resumeId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseBody<Void>> deleteResume(@PathVariable Long resumeId, @AuthenticationPrincipal Long memberId){
+        resumeService.deleteResume(resumeId, memberId);
+        return ResponseEntity.ok(createSuccessResponse());
+    }
 
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/controller/ResumeController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/controller/ResumeController.java
@@ -29,11 +29,11 @@ public class ResumeController {
 
     // 이력서 작성
     // 이미지 저장 방식: 사용자에게 이미지를 받고 서버에 저장 후 저장된 주소를 db에 저장
-    @PostMapping(value = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ResponseBody<Void>> createResume(
             @RequestPart ResumeRequest resumeRequest,
-            @RequestPart MultipartFile image,
+            @RequestPart(required = false) MultipartFile image,
             @AuthenticationPrincipal Long memberId) {
         resumeService.createResume(resumeRequest, image, memberId);
         return ResponseEntity.ok(createSuccessResponse());
@@ -51,17 +51,8 @@ public class ResumeController {
         return ResponseEntity.ok(createSuccessResponse(ResumeResponse.toResumeResponse(resume)));
     }
 
-    // 사용자의 이력서 3개를 반환
-    @GetMapping("/summary")
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ResponseBody<List<ResumeResponse>>> getResumeSummary(
-            @AuthenticationPrincipal Long memberId) {
-        List<ResumeResponse> resumeResponses = resumeService.getResumeSummary(memberId);
-        return ResponseEntity.ok(createSuccessResponse(resumeResponses));
-    }
-
     // 사용자의 전체 이력서 반환
-    @GetMapping("/all")
+    @GetMapping()
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ResponseBody<Page<ResumeResponse>>> getAllResumes
             (@AuthenticationPrincipal Long memberId,
@@ -73,13 +64,13 @@ public class ResumeController {
     // 사용자의 이력서 수정
     @PatchMapping("/{resumeId}")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ResponseBody<Void>> updateResume(
+    public ResponseEntity<ResponseBody<ResumeResponse>> updateResume(
             @RequestPart ResumeRequest resumeRequest,
             @RequestPart MultipartFile image,
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long resumeId){
-        resumeService.updateResume(resumeRequest, image, memberId, resumeId);
-        return ResponseEntity.ok(createSuccessResponse());
+        ResumeResponse response = resumeService.updateResume(resumeRequest, image, memberId, resumeId);
+        return ResponseEntity.ok(createSuccessResponse(response));
     }
 
     // 사용자의 이력서 삭제

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/controller/ResumeController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/controller/ResumeController.java
@@ -1,0 +1,86 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.controller;
+
+import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Resume;
+import kr.ac.kumoh.d138.JobForeigner.resume.dto.request.ResumeRequest;
+import kr.ac.kumoh.d138.JobForeigner.resume.dto.response.ResumeResponse;
+import kr.ac.kumoh.d138.JobForeigner.resume.service.ResumeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil.createSuccessResponse;
+
+@RestController
+@RequestMapping("api/v1/resumes")
+@RequiredArgsConstructor
+public class ResumeController {
+    private final ResumeService resumeService;
+
+    // 이력서 작성
+    // 이미지 저장 방식: 사용자에게 이미지를 받고 서버에 저장 후 저장된 주소를 db에 저장
+    @PostMapping(value = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseBody<Void>> createResume(
+            @RequestPart ResumeRequest resumeRequest,
+            @RequestPart MultipartFile image,
+            @AuthenticationPrincipal Long memberId) {
+        resumeService.createResume(resumeRequest, image, memberId);
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+
+    // 사용자는 자신의 이력서 한 개를 불러옴
+    // memberId로 member를 식별하고
+    // member의 resumeId로 해당 이력서를 불러옴
+    @GetMapping("/{resumeId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseBody<ResumeResponse>> getResume(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long resumeId) {
+        Resume resume = resumeService.getResume(memberId, resumeId);
+        return ResponseEntity.ok(createSuccessResponse(ResumeResponse.toResumeResponse(resume)));
+    }
+
+    // 사용자의 이력서 3개를 반환
+    @GetMapping("/summary")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseBody<List<ResumeResponse>>> getResumeSummary(
+            @AuthenticationPrincipal Long memberId) {
+        List<ResumeResponse> resumeResponses = resumeService.getResumeSummary(memberId);
+        return ResponseEntity.ok(createSuccessResponse(resumeResponses));
+    }
+
+    // 사용자의 전체 이력서 반환
+    @GetMapping("/all")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseBody<Page<ResumeResponse>>> getAllResumes
+            (@AuthenticationPrincipal Long memberId,
+             @PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<ResumeResponse> resumeResponses = resumeService.getAllResume(memberId, pageable);
+        return ResponseEntity.ok(createSuccessResponse(resumeResponses));
+    }
+
+    // 사용자의 이력서 수정
+    @PatchMapping("/{resumeId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseBody<Void>> updateResume(
+            @RequestPart ResumeRequest resumeRequest,
+            @RequestPart MultipartFile image,
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long resumeId){
+        resumeService.updateResume(resumeRequest, image, memberId, resumeId);
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+
+
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/controller/ResumeController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/controller/ResumeController.java
@@ -22,7 +22,7 @@ import java.util.List;
 import static kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil.createSuccessResponse;
 
 @RestController
-@RequestMapping("api/v1/resumes")
+@RequestMapping("/api/v1/resumes")
 @RequiredArgsConstructor
 public class ResumeController {
     private final ResumeService resumeService;

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/controller/ResumeController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/controller/ResumeController.java
@@ -82,6 +82,7 @@ public class ResumeController {
         return ResponseEntity.ok(createSuccessResponse());
     }
 
+    // 사용자의 이력서 삭제
     @DeleteMapping("/{resumeId}")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ResponseBody<Void>> deleteResume(@PathVariable Long resumeId, @AuthenticationPrincipal Long memberId){

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Award.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Award.java
@@ -2,11 +2,14 @@ package kr.ac.kumoh.d138.JobForeigner.resume.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Award {
     @Id
@@ -14,7 +17,7 @@ public class Award {
     private Long id;
 
     @Column(name = "award_name")
-    private String award_name;
+    private String awardName;
 
     @Column(name = "organization")
     private String organization;
@@ -25,5 +28,19 @@ public class Award {
     @Column(name = "details", columnDefinition = "TEXT")
     private String details;
 
+    @ManyToOne
+    @JoinColumn(name = "resume_id")
+    private Resume resume;
 
+    @Builder
+    public Award(String awardName, String organization, LocalDateTime year, String details){
+        this.awardName = awardName;
+        this.organization = organization;
+        this.year = year;
+        this.details = details;
+    }
+
+    public void setResume(Resume resume){
+        this.resume = resume;
+    }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Award.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Award.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -22,8 +23,8 @@ public class Award {
     @Column(name = "organization")
     private String organization;
 
-    @Column(name = "year")
-    private LocalDateTime year;
+    @Column(name = "award_year")
+    private LocalDate awardYear;
 
     @Column(name = "details", columnDefinition = "TEXT")
     private String details;
@@ -33,10 +34,10 @@ public class Award {
     private Resume resume;
 
     @Builder
-    public Award(String awardName, String organization, LocalDateTime year, String details){
+    public Award(String awardName, String organization, LocalDate awardYear, String details){
         this.awardName = awardName;
         this.organization = organization;
-        this.year = year;
+        this.awardYear = awardYear;
         this.details = details;
     }
 

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Certificate.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Certificate.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -23,14 +23,14 @@ public class Certificate {
     private String organization;
 
     @Column(name = "date")
-    private LocalDateTime date;
+    private LocalDate date;
 
     @ManyToOne
     @JoinColumn(name = "resume_id")
     private Resume resume;
 
     @Builder
-    public Certificate(String certificateName, String organization, LocalDateTime date){
+    public Certificate(String certificateName, String organization, LocalDate date){
         this.certificateName = certificateName;
         this.organization = organization;
         this.date = date;

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Certificate.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Certificate.java
@@ -2,11 +2,14 @@ package kr.ac.kumoh.d138.JobForeigner.resume.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Certificate {
     @Id
@@ -14,7 +17,7 @@ public class Certificate {
     private Long id;
 
     @Column(name = "certificate_name")
-    private String certificate_name;
+    private String certificateName;
 
     @Column(name = "organization")
     private String organization;
@@ -22,4 +25,18 @@ public class Certificate {
     @Column(name = "date")
     private LocalDateTime date;
 
+    @ManyToOne
+    @JoinColumn(name = "resume_id")
+    private Resume resume;
+
+    @Builder
+    public Certificate(String certificateName, String organization, LocalDateTime date){
+        this.certificateName = certificateName;
+        this.organization = organization;
+        this.date = date;
+    }
+
+    public void setResume(Resume resume){
+        this.resume = resume;
+    }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Education.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Education.java
@@ -6,8 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -24,7 +23,7 @@ public class Education {
     private String major;
 
     @Column(name = "year_of_graduation")
-    private LocalDateTime yearOfGraduation;
+    private LocalDate yearOfGraduation;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "degree")
@@ -42,7 +41,7 @@ public class Education {
     private Resume resume;
 
     @Builder
-    public Education(String educationName, String major, LocalDateTime yearOfGraduation, Degree degree, GraduationStatus graduationStatus, String etc){
+    public Education(String educationName, String major, LocalDate yearOfGraduation, Degree degree, GraduationStatus graduationStatus, String etc){
         this.educationName = educationName;
         this.major = major;
         this.yearOfGraduation = yearOfGraduation;

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Education.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Education.java
@@ -2,12 +2,15 @@ package kr.ac.kumoh.d138.JobForeigner.resume.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Education {
     @Id
@@ -15,20 +18,38 @@ public class Education {
     private Long id;
 
     @Column(name = "education_name")
-    private String education_name;
+    private String educationName;
 
     @Column(name = "major")
     private String major;
 
     @Column(name = "year_of_graduation")
-    private LocalDateTime year_of_graduation;
+    private LocalDateTime yearOfGraduation;
 
     @Column(name = "degree")
     private Degree degree;
 
     @Column(name = "graduation_status")
-    private GraduationStatus graduation_status;
+    private GraduationStatus graduationStatus;
 
     @Column(name = "etc", columnDefinition = "TEXT")
     private String etc;
+
+    @ManyToOne
+    @JoinColumn(name = "resume_id")
+    private Resume resume;
+
+    @Builder
+    public Education(String educationName, String major, LocalDateTime yearOfGraduation, Degree degree, GraduationStatus graduationStatus, String etc){
+        this.educationName = educationName;
+        this.major = major;
+        this.yearOfGraduation = yearOfGraduation;
+        this.degree = degree;
+        this.graduationStatus = graduationStatus;
+        this.etc = etc;
+    }
+
+    public void setResume(Resume resume){
+        this.resume = resume;
+    }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Education.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Education.java
@@ -26,9 +26,11 @@ public class Education {
     @Column(name = "year_of_graduation")
     private LocalDateTime yearOfGraduation;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "degree")
     private Degree degree;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "graduation_status")
     private GraduationStatus graduationStatus;
 

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Employment.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Employment.java
@@ -2,11 +2,14 @@ package kr.ac.kumoh.d138.JobForeigner.resume.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Employment {
     @Id
@@ -14,20 +17,38 @@ public class Employment {
     private Long id;
 
     @Column(name = "company_name")
-    private String company_name;
+    private String companyName;
 
     @Column(name = "department_name")
-    private String department_name;
+    private String departmentName;
 
     @Column(name = "job_title")
-    private String job_title;
+    private String jobTitle;
 
     @Column(name = "start_date")
-    private LocalDateTime start_date;
+    private LocalDateTime startDate;
 
     @Column(name = "end_date")
-    private LocalDateTime end_date;
+    private LocalDateTime endDate;
 
     @Column(name = "achievement", columnDefinition = "TEXT")
     private String achievement;
+
+    @ManyToOne
+    @JoinColumn(name = "resume_id")
+    private Resume resume;
+
+    @Builder
+    public Employment(String companyName, String departmentName, String jobTitle, LocalDateTime startDate, LocalDateTime endDate, String achievement){
+        this.companyName = companyName;
+        this.departmentName = departmentName;
+        this.jobTitle = jobTitle;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.achievement = achievement;
+    }
+
+    public void setResume(Resume resume){
+        this.resume = resume;
+    }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Expat.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Expat.java
@@ -19,7 +19,7 @@ public class Expat {
     @Column(name = "country")
     private String country;
 
-    @Column(name = "LocalDateTime")
+    @Column(name = "start_date")
     private LocalDateTime startDate;
 
     @Column(name = "end_date")

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Expat.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Expat.java
@@ -2,11 +2,14 @@ package kr.ac.kumoh.d138.JobForeigner.resume.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Expat {
     @Id
@@ -17,11 +20,27 @@ public class Expat {
     private String country;
 
     @Column(name = "LocalDateTime")
-    private LocalDateTime start_date;
+    private LocalDateTime startDate;
 
     @Column(name = "end_date")
-    private LocalDateTime end_date;
+    private LocalDateTime endDate;
 
     @Column(name = "experience", columnDefinition = "TEXT")
     private String experience;
+
+    @ManyToOne
+    @JoinColumn(name = "resume_id")
+    private Resume resume;
+
+    @Builder
+    public Expat(String country, LocalDateTime startDate, LocalDateTime endDate, String experience){
+        this.country = country;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.experience = experience;
+    }
+
+    public void setResume(Resume resume){
+        this.resume = resume;
+    }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/JobPreference.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/JobPreference.java
@@ -2,9 +2,12 @@ package kr.ac.kumoh.d138.JobForeigner.resume.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class JobPreference {
     @Id
@@ -12,14 +15,30 @@ public class JobPreference {
     private Long id;
 
     @Column(name = "desired_job")
-    private String desired_job;
+    private String desiredJob;
 
     @Column(name = "desired_employment_type")
-    private String desired_employment_type;
+    private String desiredEmploymentType;
 
     @Column(name = "desired_salary")
-    private Long desired_salary;
+    private Long desiredSalary;
 
     @Column(name = "desired_location")
-    private String desired_location;
+    private String desiredLocation;
+
+    @OneToOne
+    @JoinColumn(name = "resume_id")
+    private Resume resume;
+
+    @Builder
+    public JobPreference(String desiredJob, String desiredEmploymentType, Long desiredSalary, String desiredLocation){
+        this.desiredJob = desiredJob;
+        this.desiredEmploymentType = desiredEmploymentType;
+        this.desiredSalary = desiredSalary;
+        this.desiredLocation = desiredLocation;
+    }
+
+    public void setResume(Resume resume){
+        this.resume = resume;
+    }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Language.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Language.java
@@ -2,9 +2,12 @@ package kr.ac.kumoh.d138.JobForeigner.resume.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Language {
     @Id
@@ -16,4 +19,18 @@ public class Language {
 
     @Column(name = "proficiency")
     private String proficiency;
+
+    @ManyToOne
+    @JoinColumn(name = "resume_id")
+    private Resume resume;
+
+    @Builder
+    public Language(String languages, String proficiency){
+        this.languages = languages;
+        this.proficiency = proficiency;
+    }
+
+    public void setResume(Resume resume){
+        this.resume = resume;
+    }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Portfolio.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Portfolio.java
@@ -2,9 +2,12 @@ package kr.ac.kumoh.d138.JobForeigner.resume.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Portfolio {
     @Id
@@ -12,5 +15,18 @@ public class Portfolio {
     private Long id;
 
     @Column(name = "portfolio_url")
-    private String portfolio_url;
+    private String portfolioUrl;
+
+    @ManyToOne
+    @JoinColumn(name = "resume_id")
+    private Resume resume;
+
+    @Builder
+    public Portfolio(String portfolioUrl){
+        this.portfolioUrl = portfolioUrl;
+    }
+
+    public void setResume(Resume resume){
+        this.resume = resume;
+    }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Resume.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Resume.java
@@ -86,19 +86,57 @@ public class Resume extends BaseEntity {
                              List<Language> languages, List<Portfolio> portfolios, JobPreference jobPreference, List<Expat> expats
     ) {
         this.resumeImageUrl = resumeImageUrl;
-        this.educations = educations;
-        this.employments = employments;
-        this.certificates = certificates;
-        this.awards = awards;
-        this.skills = skills;
-        this.languages = languages;
-        this.portfolios = portfolios;
-        this.jobPreference = jobPreference;
-        this.expat = expats;
+        
+        if(educations != null) {
+            this.educations.clear();
+            this.educations.addAll(educations);
+        }
+        
+        if(employments != null) {
+            this.employments.clear();
+            this.employments.addAll(employments); 
+        }
+
+        if (certificates != null) {
+            this.certificates.clear();
+            this.certificates.addAll(certificates);
+        }
+
+        if (awards != null) {
+            this.awards.clear();
+            this.awards.addAll(awards);
+        }
+
+        if (skills != null) {
+            this.skills.clear();
+            this.skills.addAll(skills);
+        }
+
+        if (languages != null) {
+            this.languages.clear();
+            this.languages.addAll(languages);
+        }
+
+        if (portfolios != null) {
+            this.portfolios.clear();
+            this.portfolios.addAll(portfolios);
+        }
+
+        if (expats != null) {
+            this.expat.clear();
+            this.expat.addAll(expats);
+        }
+
+        if (jobPreference != null) {
+            this.jobPreference = jobPreference;
+        }
+
+        // 연관관계 설정
+        updateAllRelation(this);
     }
 
     // 양방향 연관관계 설정을 위한 편의 메서드
-    public void createResume(Resume resume
+    public void updateAllRelation(Resume resume
     ){
         resume.getEducations().forEach(education -> education.setResume(this));
         resume.getEmployments().forEach(employment -> employment.setResume(this));

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Resume.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Resume.java
@@ -9,7 +9,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -80,5 +79,35 @@ public class Resume extends BaseEntity {
         this.portfolios = portfolios != null ? portfolios : new ArrayList<>();
         this.jobPreference = jobPreference;
         this.expat = expat != null ? expat : new ArrayList<>();
+    }
+
+    public void updateResume(String resumeImageUrl, List<Education> educations, List<Employment> employments,
+                             List<Certificate> certificates, List<Award> awards, List<Skill> skills,
+                             List<Language> languages, List<Portfolio> portfolios, JobPreference jobPreference, List<Expat> expats
+    ) {
+        this.resumeImageUrl = resumeImageUrl;
+        this.educations = educations;
+        this.employments = employments;
+        this.certificates = certificates;
+        this.awards = awards;
+        this.skills = skills;
+        this.languages = languages;
+        this.portfolios = portfolios;
+        this.jobPreference = jobPreference;
+        this.expat = expats;
+    }
+
+    // 양방향 연관관계 설정을 위한 편의 메서드
+    public void createResume(Resume resume
+    ){
+        resume.getEducations().forEach(education -> education.setResume(this));
+        resume.getEmployments().forEach(employment -> employment.setResume(this));
+        resume.getCertificates().forEach(certificate -> certificate.setResume(this));
+        resume.getAwards().forEach(award -> award.setResume(this));
+        resume.getSkills().forEach(skill -> skill.setResume(this));
+        resume.getLanguages().forEach(language -> language.setResume(this));
+        resume.getPortfolios().forEach(portfolio -> portfolio.setResume(this));
+        resume.getJobPreference().setResume(this);
+        resume.getExpat().forEach(expat -> expat.setResume(this));
     }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Skill.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/domain/Skill.java
@@ -2,9 +2,12 @@ package kr.ac.kumoh.d138.JobForeigner.resume.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Skill {
     @Id
@@ -12,5 +15,18 @@ public class Skill {
     private Long id;
 
     @Column(name = "skill_name")
-    private String skill_name;
+    private String skillName;
+
+    @ManyToOne
+    @JoinColumn(name = "resume_id")
+    private Resume resume;
+
+    @Builder
+    public Skill(String skillName){
+        this.skillName = skillName;
+    }
+
+    public void setResume(Resume resume){
+        this.resume = resume;
+    }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/AwardsRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/AwardsRequest.java
@@ -3,19 +3,20 @@ package kr.ac.kumoh.d138.JobForeigner.resume.dto.request;
 
 import kr.ac.kumoh.d138.JobForeigner.resume.domain.Award;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record AwardsRequest(
     String awardName,
     String organization,
-    LocalDateTime year,
+    LocalDate awardYear,
     String details
 ) {
     public Award toAward(){
         return Award.builder()
                 .awardName(awardName)
                 .organization(organization)
-                .year(year)
+                .awardYear(awardYear)
                 .details(details)
                 .build();
     }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/AwardsRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/AwardsRequest.java
@@ -1,0 +1,22 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.request;
+
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Award;
+
+import java.time.LocalDateTime;
+
+public record AwardsRequest(
+    String awardName,
+    String organization,
+    LocalDateTime year,
+    String details
+) {
+    public Award toAward(){
+        return Award.builder()
+                .awardName(awardName)
+                .organization(organization)
+                .year(year)
+                .details(details)
+                .build();
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/CertificatesRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/CertificatesRequest.java
@@ -3,12 +3,12 @@ package kr.ac.kumoh.d138.JobForeigner.resume.dto.request;
 
 import kr.ac.kumoh.d138.JobForeigner.resume.domain.Certificate;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public record CertificatesRequest(
         String certificateName,
         String organization,
-        LocalDateTime date
+        LocalDate date
 ) {
     public Certificate toCertificate(){
         return Certificate.builder()

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/CertificatesRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/CertificatesRequest.java
@@ -1,0 +1,20 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.request;
+
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Certificate;
+
+import java.time.LocalDateTime;
+
+public record CertificatesRequest(
+        String certificateName,
+        String organization,
+        LocalDateTime date
+) {
+    public Certificate toCertificate(){
+        return Certificate.builder()
+                .certificateName(certificateName)
+                .organization(organization)
+                .date(date)
+                .build();
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/EducationRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/EducationRequest.java
@@ -1,0 +1,27 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.request;
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Degree;
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Education;
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.GraduationStatus;
+
+import java.time.LocalDateTime;
+
+public record EducationRequest(
+        String educationName,
+        String major,
+        LocalDateTime yearOfGraduation,
+        Degree degree,
+        GraduationStatus graduationStatus,
+        String etc
+) {
+    public Education toEducation(){
+        return Education.builder()
+                .educationName(educationName)
+                .major(major)
+                .yearOfGraduation(yearOfGraduation)
+                .degree(degree)
+                .graduationStatus(graduationStatus)
+                .etc(etc)
+                .build();
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/EducationRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/EducationRequest.java
@@ -4,12 +4,12 @@ import kr.ac.kumoh.d138.JobForeigner.resume.domain.Degree;
 import kr.ac.kumoh.d138.JobForeigner.resume.domain.Education;
 import kr.ac.kumoh.d138.JobForeigner.resume.domain.GraduationStatus;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public record EducationRequest(
         String educationName,
         String major,
-        LocalDateTime yearOfGraduation,
+        LocalDate yearOfGraduation,
         Degree degree,
         GraduationStatus graduationStatus,
         String etc

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/EmploymentRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/EmploymentRequest.java
@@ -1,0 +1,26 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.request;
+
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Employment;
+
+import java.time.LocalDateTime;
+
+public record EmploymentRequest (
+        String companyName,
+        String departmentName,
+        String jobTitle,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        String achievement
+){
+    public Employment toEmployment(){
+        return Employment.builder()
+                .companyName(companyName)
+                .departmentName(departmentName)
+                .jobTitle(jobTitle)
+                .startDate(startDate)
+                .endDate(endDate)
+                .achievement(achievement)
+                .build();
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/ExpatRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/ExpatRequest.java
@@ -1,0 +1,22 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.request;
+
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Expat;
+
+import java.time.LocalDateTime;
+
+public record ExpatRequest(
+        String country,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        String experience
+) {
+    public Expat toExpat(){
+        return Expat.builder()
+                .country(country)
+                .startDate(startDate)
+                .endDate(endDate)
+                .experience(experience)
+                .build();
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/JobPreferenceRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/JobPreferenceRequest.java
@@ -1,0 +1,20 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.request;
+
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.JobPreference;
+
+public record JobPreferenceRequest(
+        String desiredJob,
+        String desiredEmploymentType,
+        Long desiredSalary,
+        String desiredLocation
+) {
+    public JobPreference toJobPreference() {
+        return JobPreference.builder()
+                .desiredJob(desiredJob)
+                .desiredEmploymentType(desiredEmploymentType)
+                .desiredSalary(desiredSalary)
+                .desiredLocation(desiredLocation)
+                .build();
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/LanguagesRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/LanguagesRequest.java
@@ -1,0 +1,15 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.request;
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Language;
+
+public record LanguagesRequest(
+        String languages,
+        String proficiency
+) {
+    public Language toLanguage(){
+        return Language.builder()
+                .languages(languages)
+                .proficiency(proficiency)
+                .build();
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/PortfoliosRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/PortfoliosRequest.java
@@ -1,0 +1,13 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.request;
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Portfolio;
+
+public record PortfoliosRequest(
+        String portfolioUrl
+) {
+    public Portfolio toPortfolio(){
+        return Portfolio.builder()
+                .portfolioUrl(portfolioUrl)
+                .build();
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/ResumeRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/ResumeRequest.java
@@ -1,0 +1,18 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.request;
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.*;
+import java.util.List;
+
+public record ResumeRequest(
+        List<EducationRequest> educations,
+        List<EmploymentRequest> employments,
+        List<CertificatesRequest> certificates,
+        List<AwardsRequest> awards,
+        List<SkillsRequest> skills,
+        List<LanguagesRequest> languages,
+        List<PortfoliosRequest> portfolios,
+        JobPreferenceRequest jobPreference,
+        List<ExpatRequest> expat
+) {
+
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/SkillsRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/SkillsRequest.java
@@ -3,11 +3,11 @@ package kr.ac.kumoh.d138.JobForeigner.resume.dto.request;
 import kr.ac.kumoh.d138.JobForeigner.resume.domain.Skill;
 
 public record SkillsRequest (
-        String skill_name
+        String skillName
 ){
     public Skill toSkill(){
         return Skill.builder()
-                .skillName(skill_name)
+                .skillName(skillName)
                 .build();
     }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/SkillsRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/request/SkillsRequest.java
@@ -1,0 +1,13 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.request;
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Skill;
+
+public record SkillsRequest (
+        String skill_name
+){
+    public Skill toSkill(){
+        return Skill.builder()
+                .skillName(skill_name)
+                .build();
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/AwardsResponse.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/AwardsResponse.java
@@ -3,13 +3,14 @@ package kr.ac.kumoh.d138.JobForeigner.resume.dto.response;
 import kr.ac.kumoh.d138.JobForeigner.resume.domain.Award;
 import kr.ac.kumoh.d138.JobForeigner.resume.domain.Resume;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record AwardsResponse(
     String awardName,
     String organization,
-    LocalDateTime year,
+    LocalDate awardYear,
     String details
 ) {
 
@@ -17,7 +18,7 @@ public record AwardsResponse(
         return new AwardsResponse(
                 award.getAwardName(),
                 award.getOrganization(),
-                award.getYear(),
+                award.getAwardYear(),
                 award.getDetails()
         );
     }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/AwardsResponse.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/AwardsResponse.java
@@ -1,0 +1,30 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.response;
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Award;
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Resume;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AwardsResponse(
+    String awardName,
+    String organization,
+    LocalDateTime year,
+    String details
+) {
+
+    public static AwardsResponse toAwardResponse(Award award) {
+        return new AwardsResponse(
+                award.getAwardName(),
+                award.getOrganization(),
+                award.getYear(),
+                award.getDetails()
+        );
+    }
+
+    public static List<AwardsResponse> toAwardsResponseList(Resume resume) {
+        return resume.getAwards().stream()
+                .map(AwardsResponse::toAwardResponse)
+                .toList();
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/CertificatesResponse.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/CertificatesResponse.java
@@ -3,13 +3,13 @@ package kr.ac.kumoh.d138.JobForeigner.resume.dto.response;
 import kr.ac.kumoh.d138.JobForeigner.resume.domain.Certificate;
 import kr.ac.kumoh.d138.JobForeigner.resume.domain.Resume;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 public record CertificatesResponse(
         String certificateName,
         String organization,
-        LocalDateTime date
+        LocalDate date
 ) {
     public static CertificatesResponse toCertificatesResponse(Certificate certificate){
         return new CertificatesResponse(

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/CertificatesResponse.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/CertificatesResponse.java
@@ -1,0 +1,28 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.response;
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Certificate;
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Resume;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CertificatesResponse(
+        String certificateName,
+        String organization,
+        LocalDateTime date
+) {
+    public static CertificatesResponse toCertificatesResponse(Certificate certificate){
+        return new CertificatesResponse(
+                certificate.getCertificateName(),
+                certificate.getOrganization(),
+                certificate.getDate()
+        );
+    }
+
+    public static List<CertificatesResponse> toCertificatesResponseList(Resume resume){
+        return resume.getCertificates().stream()
+                .map(CertificatesResponse::toCertificatesResponse)
+                .toList();
+    }
+
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/EducationResponse.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/EducationResponse.java
@@ -5,13 +5,13 @@ import kr.ac.kumoh.d138.JobForeigner.resume.domain.Education;
 import kr.ac.kumoh.d138.JobForeigner.resume.domain.GraduationStatus;
 import kr.ac.kumoh.d138.JobForeigner.resume.domain.Resume;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 public record EducationResponse(
         String educationName,
         String major,
-        LocalDateTime yearOfGraduation,
+        LocalDate yearOfGraduation,
         Degree degree,
         GraduationStatus graduationStatus,
         String etc

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/EducationResponse.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/EducationResponse.java
@@ -1,0 +1,35 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.response;
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Degree;
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Education;
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.GraduationStatus;
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Resume;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record EducationResponse(
+        String educationName,
+        String major,
+        LocalDateTime yearOfGraduation,
+        Degree degree,
+        GraduationStatus graduationStatus,
+        String etc
+) {
+    public static EducationResponse toEducationResponse(Education education) {
+        return new EducationResponse(
+                education.getEducationName(),
+                education.getMajor(),
+                education.getYearOfGraduation(),
+                education.getDegree(),
+                education.getGraduationStatus(),
+                education.getEtc()
+        );
+    }
+
+    public static List<EducationResponse> toEducationResponseList(Resume resume) {
+        return resume.getEducations().stream()
+                .map(EducationResponse::toEducationResponse)
+                .toList();
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/EmploymentResponse.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/EmploymentResponse.java
@@ -1,0 +1,33 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.response;
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Employment;
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Resume;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record EmploymentResponse(
+        String companyName,
+        String departmentName,
+        String jobTitle,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        String achievement
+){
+    public static EmploymentResponse toEmploymentResponse(Employment employment) {
+        return new EmploymentResponse(
+                employment.getCompanyName(),
+                employment.getDepartmentName(),
+                employment.getJobTitle(),
+                employment.getStartDate(),
+                employment.getEndDate(),
+                employment.getAchievement()
+        );
+    }
+
+    public static List<EmploymentResponse> toEmploymentResponseList(Resume resume) {
+        return resume.getEmployments().stream()
+                .map(EmploymentResponse::toEmploymentResponse)
+                .toList();
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/ExpatResponse.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/ExpatResponse.java
@@ -1,0 +1,29 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.response;
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Expat;
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Resume;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ExpatResponse(
+        String country,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        String experience
+) {
+    public static ExpatResponse toExpatResponse(Expat expat) {
+        return new ExpatResponse(
+                expat.getCountry(),
+                expat.getStartDate(),
+                expat.getEndDate(),
+                expat.getExperience()
+        );
+    }
+
+    public static List<ExpatResponse> toExpatResponseList(Resume resume) {
+        return resume.getExpat().stream()
+                .map(ExpatResponse::toExpatResponse)
+                .toList();
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/JobPreferenceResponse.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/JobPreferenceResponse.java
@@ -1,0 +1,22 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.response;
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.JobPreference;
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Resume;
+
+import java.util.List;
+
+public record JobPreferenceResponse(
+        String desiredJob,
+        String desiredEmploymentType,
+        Long desiredSalary,
+        String desiredLocation
+) {
+    public static JobPreferenceResponse toJobPreferenceResponse(Resume resume) {
+        return new JobPreferenceResponse(
+                resume.getJobPreference().getDesiredJob(),
+                resume.getJobPreference().getDesiredEmploymentType(),
+                resume.getJobPreference().getDesiredSalary(),
+                resume.getJobPreference().getDesiredLocation()
+        );
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/LanguagesResponse.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/LanguagesResponse.java
@@ -1,0 +1,24 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.response;
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Language;
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Resume;
+
+import java.util.List;
+
+public record LanguagesResponse(
+        String languages,
+        String proficiency
+) {
+    public static LanguagesResponse toLanguagesResponse(Language language) {
+        return new LanguagesResponse(
+                language.getLanguages(),
+                language.getProficiency()
+        );
+    }
+
+    public static List<LanguagesResponse> toLanguagesResponseList(Resume resume) {
+        return resume.getLanguages().stream()
+                .map(LanguagesResponse::toLanguagesResponse)
+                .toList();
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/PortfoliosResponse.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/PortfoliosResponse.java
@@ -1,0 +1,22 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.response;
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Portfolio;
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Resume;
+
+import java.util.List;
+
+public record PortfoliosResponse(
+        String portfolioUrl
+) {
+    public static PortfoliosResponse toPortfolioResponse(Portfolio portfolio) {
+        return new PortfoliosResponse(
+                portfolio.getPortfolioUrl()
+        );
+    }
+
+    public static List<PortfoliosResponse> toPortfoliosResponseList(Resume resume) {
+        return resume.getPortfolios().stream()
+                .map(PortfoliosResponse::toPortfolioResponse)
+                .toList();
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/ResumeResponse.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/ResumeResponse.java
@@ -1,0 +1,40 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.response;
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Resume;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ResumeResponse(
+        Long resumeId,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        List<EducationResponse> educations,
+        List<EmploymentResponse> employments,
+        List<CertificatesResponse> certificates,
+        List<AwardsResponse> awards,
+        List<SkillsResponse> skills,
+        List<LanguagesResponse> languages,
+        List<PortfoliosResponse> portfolios,
+        JobPreferenceResponse jobPreference,
+        List<ExpatResponse> expats,
+        String imageUrl
+) {
+    public static ResumeResponse toResumeResponse(Resume resume) {
+        return new ResumeResponse(
+                resume.getId(),
+                resume.getCreatedAt(),
+                resume.getUpdatedAt(),
+                EducationResponse.toEducationResponseList(resume),
+                EmploymentResponse.toEmploymentResponseList(resume),
+                CertificatesResponse.toCertificatesResponseList(resume),
+                AwardsResponse.toAwardsResponseList(resume),
+                SkillsResponse.toSkillsResponseList(resume),
+                LanguagesResponse.toLanguagesResponseList(resume),
+                PortfoliosResponse.toPortfoliosResponseList(resume),
+                JobPreferenceResponse.toJobPreferenceResponse(resume),
+                ExpatResponse.toExpatResponseList(resume),
+                resume.getMember().getProfileImageUrl()
+        );
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/SkillsResponse.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/SkillsResponse.java
@@ -6,7 +6,7 @@ import kr.ac.kumoh.d138.JobForeigner.resume.domain.Skill;
 import java.util.List;
 
 public record SkillsResponse(
-        String skill_name
+        String skillName
 ){
     public static SkillsResponse toSkillsResponse(Skill skill) {
         return new SkillsResponse(

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/SkillsResponse.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/dto/response/SkillsResponse.java
@@ -1,0 +1,22 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.dto.response;
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Resume;
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Skill;
+
+import java.util.List;
+
+public record SkillsResponse(
+        String skill_name
+){
+    public static SkillsResponse toSkillsResponse(Skill skill) {
+        return new SkillsResponse(
+                skill.getSkillName()
+        );
+    }
+
+    public static List<SkillsResponse> toSkillsResponseList(Resume resume) {
+        return resume.getSkills().stream()
+                .map(SkillsResponse::toSkillsResponse)
+                .toList();
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/repository/ResumeRepository.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/repository/ResumeRepository.java
@@ -5,6 +5,7 @@ import kr.ac.kumoh.d138.JobForeigner.resume.dto.response.ResumeResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,5 +15,5 @@ public interface ResumeRepository extends JpaRepository<Resume,Long> {
 
     Page<Resume> findAllByMemberId(Long memberId, Pageable pageable);
 
-    List<Resume> findTop3ByMemberIdOrderByUpdatedAtAsc(Long memberId);
+    List<Resume> findTop3ByMemberIdOrderByUpdatedAtDesc(Long memberId);
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/repository/ResumeRepository.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/repository/ResumeRepository.java
@@ -1,0 +1,18 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.repository;
+
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Resume;
+import kr.ac.kumoh.d138.JobForeigner.resume.dto.response.ResumeResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ResumeRepository extends JpaRepository<Resume,Long> {
+    Optional<Resume> findByIdAndMemberId(Long resumeId, Long memberId);
+
+    Page<Resume> findAllByMemberId(Long memberId, Pageable pageable);
+
+    List<Resume> findTop3ByMemberIdOrderByUpdatedAtAsc(Long memberId);
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/service/ResumeService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/service/ResumeService.java
@@ -189,4 +189,8 @@ public class ResumeService {
         return ResumeResponse.toResumeResponse(response);
 
     }
+
+    public void deleteResume(Long memberId, Long resumeId) {
+        resumeRepository.deleteById(resumeId);
+    }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/service/ResumeService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/service/ResumeService.java
@@ -10,6 +10,7 @@ import kr.ac.kumoh.d138.JobForeigner.resume.dto.request.*;
 import kr.ac.kumoh.d138.JobForeigner.resume.dto.response.ResumeResponse;
 import kr.ac.kumoh.d138.JobForeigner.resume.repository.ResumeRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -25,6 +26,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ResumeService {
@@ -90,7 +92,7 @@ public class ResumeService {
 
 
         // 양방향 연관관계 설정
-        resume.createResume(resume);
+        resume.updateAllRelation(resume);
 
         // 3. 저장
         resumeRepository.save(resume);
@@ -148,35 +150,37 @@ public class ResumeService {
             imageUrl = storeImage(image);
         }
 
+        log.error("입력받은 내용 : {}", request.toString());
+
         resume.updateResume(
                 imageUrl != null ? imageUrl : resume.getResumeImageUrl(),
                 request.educations() != null
                         ? request.educations().stream().map(EducationRequest::toEducation).collect(Collectors.toList())
-                        : resume.getEducations(),
+                        : null,
                 request.employments() != null
                         ? request.employments().stream().map(EmploymentRequest::toEmployment).collect(Collectors.toList())
-                        : resume.getEmployments(),
+                        : null,
                 request.certificates() != null
                         ? request.certificates().stream().map(CertificatesRequest::toCertificate).collect(Collectors.toList())
-                        : resume.getCertificates(),
+                        : null,
                 request.awards() != null
                         ? request.awards().stream().map(AwardsRequest::toAward).collect(Collectors.toList())
-                        : resume.getAwards(),
+                        : null,
                 request.skills() != null
                         ? request.skills().stream().map(SkillsRequest::toSkill).collect(Collectors.toList())
-                        : resume.getSkills(),
+                        : null,
                 request.languages() != null
                         ? request.languages().stream().map(LanguagesRequest::toLanguage).collect(Collectors.toList())
-                        : resume.getLanguages(),
+                        : null,
                 request.portfolios() != null
                         ? request.portfolios().stream().map(PortfoliosRequest::toPortfolio).collect(Collectors.toList())
-                        : resume.getPortfolios(),
+                        : null,
                 request.jobPreference() != null
                         ? request.jobPreference().toJobPreference()
-                        : resume.getJobPreference(),
+                        : null,
                 request.expat() != null
                         ? request.expat().stream().map(ExpatRequest::toExpat).collect(Collectors.toList())
-                        : resume.getExpat()
+                        : null
         );
 
         Resume response = resumeRepository.findById(resumeId)

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/service/ResumeService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/service/ResumeService.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ResumeService {
@@ -124,13 +123,6 @@ public class ResumeService {
                 .orElseThrow(()->new BusinessException(ExceptionType.RESUME_FORBIDDEN));
     }
 
-    public List<ResumeResponse> getResumeSummary(Long memberId) {
-        List<Resume> response = resumeRepository.findTop3ByMemberIdOrderByUpdatedAtAsc(memberId);
-        return response.stream()
-                .map(ResumeResponse::toResumeResponse)
-                .toList();
-    }
-
     public Page<ResumeResponse> getAllResume(Long memberId, Pageable pageable) {
         Page<Resume> response = resumeRepository.findAllByMemberId(memberId, pageable);
         return response.map(ResumeResponse::toResumeResponse);
@@ -149,8 +141,6 @@ public class ResumeService {
         if(image != null && !image.isEmpty()) {
             imageUrl = storeImage(image);
         }
-
-        log.error("입력받은 내용 : {}", request.toString());
 
         resume.updateResume(
                 imageUrl != null ? imageUrl : resume.getResumeImageUrl(),
@@ -190,7 +180,11 @@ public class ResumeService {
 
     }
 
-    public void deleteResume(Long memberId, Long resumeId) {
+    public void deleteResume(Long resumeId, Long memberId) {
+        Resume resume = resumeRepository.findById(resumeId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.RESUME_NOT_FOUND));
+        if (!resume.getMember().getId().equals(memberId))
+            throw new BusinessException(ExceptionType.RESUME_FORBIDDEN);
         resumeRepository.deleteById(resumeId);
     }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/service/ResumeService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/service/ResumeService.java
@@ -1,0 +1,188 @@
+package kr.ac.kumoh.d138.JobForeigner.resume.service;
+
+import jakarta.transaction.Transactional;
+import kr.ac.kumoh.d138.JobForeigner.global.exception.BusinessException;
+import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
+import kr.ac.kumoh.d138.JobForeigner.member.domain.Member;
+import kr.ac.kumoh.d138.JobForeigner.member.repository.MemberRepository;
+import kr.ac.kumoh.d138.JobForeigner.resume.domain.Resume;
+import kr.ac.kumoh.d138.JobForeigner.resume.dto.request.*;
+import kr.ac.kumoh.d138.JobForeigner.resume.dto.response.ResumeResponse;
+import kr.ac.kumoh.d138.JobForeigner.resume.repository.ResumeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ResumeService {
+
+    private final ResumeRepository resumeRepository;
+    private final MemberRepository memberRepository;
+
+    private final String UPLOAD_DIR = "";
+
+    // TODO: 서버 컴 세팅 완료하기
+    @Transactional
+    public void createResume(ResumeRequest request, MultipartFile image, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.MEMBER_NOT_FOUND));
+
+        // 1. 이미지 저장
+        // 서버 세팅 전까지 주석 처리
+        // String imageUrl = storeImage(image);
+
+        String imageUrl = "/images";
+
+        // 2. Resume 생성
+        Resume resume = Resume.builder()
+                .member(member)
+                .resumeImageUrl(imageUrl)
+                .educations(
+                        request.educations() != null
+                                ? request.educations().stream().map(EducationRequest::toEducation).collect(Collectors.toList())
+                                : new ArrayList<>())
+                .employments(
+                        request.employments() != null
+                                ? request.employments().stream().map(EmploymentRequest::toEmployment).collect(Collectors.toList())
+                                : new ArrayList<>())
+                .certificates(
+                        request.certificates() != null
+                                ? request.certificates().stream().map(CertificatesRequest::toCertificate).collect(Collectors.toList())
+                                : new ArrayList<>())
+                .awards(
+                        request.awards() != null
+                                ? request.awards().stream().map(AwardsRequest::toAward).collect(Collectors.toList())
+                                : new ArrayList<>())
+                .skills(
+                        request.skills() != null
+                                ? request.skills().stream().map(SkillsRequest::toSkill).collect(Collectors.toList())
+                                : new ArrayList<>())
+                .languages(
+                        request.languages() != null
+                                ? request.languages().stream().map(LanguagesRequest::toLanguage).collect(Collectors.toList())
+                                : new ArrayList<>())
+                .portfolios(
+                        request.portfolios() != null
+                                ? request.portfolios().stream().map(PortfoliosRequest::toPortfolio).collect(Collectors.toList())
+                                : new ArrayList<>())
+                .jobPreference(
+                        request.jobPreference() != null
+                                ? request.jobPreference().toJobPreference()
+                                : null)
+                .expat(
+                        request.expat() != null
+                                ? request.expat().stream().map(ExpatRequest::toExpat).collect(Collectors.toList())
+                                : new ArrayList<>())
+                .build();
+
+
+        // 양방향 연관관계 설정
+        resume.createResume(resume);
+
+        // 3. 저장
+        resumeRepository.save(resume);
+    }
+
+    // 이미지 저장 후 저장된 주소를 반환
+    // TODO: 이전에 저장된 이미지를 삭제하는 로직 필요
+    public String storeImage(MultipartFile file) {
+        try {
+            // 이미지의 확장자 추출
+            String ext = Optional.ofNullable(file.getOriginalFilename())
+                    .filter(f -> f.contains("."))
+                    .map(f -> f.substring(f.lastIndexOf(".")))
+                    .orElse("");
+
+            String savedName = UUID.randomUUID() + ext;
+            Path savePath = Paths.get(UPLOAD_DIR, savedName);
+            Files.createDirectories(savePath.getParent());
+            file.transferTo(savePath.toFile());
+
+            return "/images/" + savedName;
+        } catch (IOException e) {
+            throw new RuntimeException("이미지 저장 실패", e);
+        }
+    }
+
+    public Resume getResume(Long memberId, Long resumeId) {
+        return resumeRepository.findByIdAndMemberId(resumeId, memberId)
+                .orElseThrow(()->new BusinessException(ExceptionType.RESUME_FORBIDDEN));
+    }
+
+    public List<ResumeResponse> getResumeSummary(Long memberId) {
+        List<Resume> response = resumeRepository.findTop3ByMemberIdOrderByUpdatedAtAsc(memberId);
+        return response.stream()
+                .map(ResumeResponse::toResumeResponse)
+                .toList();
+    }
+
+    public Page<ResumeResponse> getAllResume(Long memberId, Pageable pageable) {
+        Page<Resume> response = resumeRepository.findAllByMemberId(memberId, pageable);
+        return response.map(ResumeResponse::toResumeResponse);
+    }
+
+    @Transactional
+    public ResumeResponse updateResume(ResumeRequest request, MultipartFile image, Long memberId, Long resumeId) {
+        Resume resume = resumeRepository.findById(resumeId)
+                .orElseThrow(()-> new BusinessException(ExceptionType.RESUME_NOT_FOUND));
+
+        if(!resume.getMember().getId().equals(memberId)) {
+            throw new BusinessException(ExceptionType.RESUME_FORBIDDEN);
+        }
+
+        String imageUrl = null;
+        if(image != null && !image.isEmpty()) {
+            imageUrl = storeImage(image);
+        }
+
+        resume.updateResume(
+                imageUrl != null ? imageUrl : resume.getResumeImageUrl(),
+                request.educations() != null
+                        ? request.educations().stream().map(EducationRequest::toEducation).collect(Collectors.toList())
+                        : resume.getEducations(),
+                request.employments() != null
+                        ? request.employments().stream().map(EmploymentRequest::toEmployment).collect(Collectors.toList())
+                        : resume.getEmployments(),
+                request.certificates() != null
+                        ? request.certificates().stream().map(CertificatesRequest::toCertificate).collect(Collectors.toList())
+                        : resume.getCertificates(),
+                request.awards() != null
+                        ? request.awards().stream().map(AwardsRequest::toAward).collect(Collectors.toList())
+                        : resume.getAwards(),
+                request.skills() != null
+                        ? request.skills().stream().map(SkillsRequest::toSkill).collect(Collectors.toList())
+                        : resume.getSkills(),
+                request.languages() != null
+                        ? request.languages().stream().map(LanguagesRequest::toLanguage).collect(Collectors.toList())
+                        : resume.getLanguages(),
+                request.portfolios() != null
+                        ? request.portfolios().stream().map(PortfoliosRequest::toPortfolio).collect(Collectors.toList())
+                        : resume.getPortfolios(),
+                request.jobPreference() != null
+                        ? request.jobPreference().toJobPreference()
+                        : resume.getJobPreference(),
+                request.expat() != null
+                        ? request.expat().stream().map(ExpatRequest::toExpat).collect(Collectors.toList())
+                        : resume.getExpat()
+        );
+
+        Resume response = resumeRepository.findById(resumeId)
+                .orElseThrow(()->new BusinessException(ExceptionType.RESUME_NOT_FOUND));
+
+        return ResumeResponse.toResumeResponse(response);
+
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -58,3 +58,10 @@ job-foreigner:
         subject: "[JobForeigner] Please verify your email address."
         base-url: "https://example.com"
         verify-path: "/api/v1/email/auth/verify?code="
+  all:
+    open-api:
+      validate-business-number:
+        host: api.example.kr
+        path: /api/nts-businessman/v1/validate
+        encoding-key: "Wv6%40hZpR8%24D2nQxE%26z1jS%21wM5fCu3%25GkLbA9%5EVtYsXpJqUo*H4eBi0NrTZ7I%23cKymOFdPWgX%24Mv%40sYQh*6B%21aJr%23uLn9N2%5EtTzXk3l0%25pZ5oU4CejiVb7wSf8D"
+        decoding-key: "Wv6@hZpR8$D2nQxE&z1jS!wM5fCu3%GkLbA9^VtYsXpJqUo*H4eBi0NrTZ7I#cKymOFdPWgX$Mv@sYQh*6B!aJr#uLn9N2^tTzXk3l0%pZ5oU4CejiVb7wSf8D"


### PR DESCRIPTION
## What is this PR?🔍
- 이력서 생성/수정/조회 api를 개발했습니다.
- 연관관계 설정을 위한 편의 메서드를 생성했습니다.
- 비지니스 로직에서 반복되는 코드는 추후에 리팩터링하겠습니다.
- 이미지 관련 로직은 테스트되지 않았습니다. 서버 세팅 후 수정하겠습니다
## Changes💻
- 이력서 생성 시 @RequestPart를 사용합니다. 이 어노테이션은 multipart/form-data 형식으로 요청을 받습니다.
- 엔티티 간 연관관계에서, 주인이 아닌 쪽에서 관계를 설정하면 외래 키가 제대로 반영되지 않습니다. 
- 이때 편의 메서드를 사용하면 양쪽 엔티티의 관계를 동시에 설정해줘서, 연관관계가 꼬이지 않고 정상적으로 작동하게 됩니다

## ScreenShot📷
- 이력서 생성 시 응답
<img width="174" alt="image" src="https://github.com/user-attachments/assets/2d7b1b46-e1e4-4535-bfa9-51bca795fd69" />

- 이력서 1개 조회 시 응답
![image](https://github.com/user-attachments/assets/8c70bfd3-7c22-4814-ab4f-123507985115)
- 이력서 3개 조회 시 응답. 리스트로 반환합니다
![image](https://github.com/user-attachments/assets/1ade3649-d0a0-4fc1-84f8-24c0ba32dfce)
- 전체 이력서 응답. 페이지로 반환합니다
![image](https://github.com/user-attachments/assets/c061c148-5fc9-4af0-8012-01b3a09645f4)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **신규 기능**
  - 이력서(Resume) 관리 기능이 추가되어, 사용자는 이력서를 생성, 조회, 수정, 삭제할 수 있습니다.
  - 이력서에는 학력, 경력, 자격증, 수상, 기술, 언어, 포트폴리오, 해외경험, 희망 직무 등 다양한 항목을 포함할 수 있습니다.
  - 이력서별 프로필 이미지 업로드 및 변경이 가능합니다.
  - 이력서 요약 및 전체 목록 조회, 페이징 기능이 제공됩니다.

- **버그 수정**
  - 이력서 접근 권한 및 존재하지 않는 이력서에 대한 예외 처리가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->