### PR TITLE
chore: CORS 설정 수정

### DIFF
--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/config/security/CorsConfig.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/config/security/CorsConfig.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class CorsConfig {
     public static CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:8080"));
+        configuration.setAllowedOrigins(List.of("http://localhost:5173"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setMaxAge(3600L);


### PR DESCRIPTION
## What is this PR?🔍
- 프론트엔드 API 연동을 위해 CORS 설정을 수정합니다.

## Changes💻
- `localhost:5173`에서 API 요청이 가능하도록 수정

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - CORS 허용 origin이 "http://localhost:8080"에서 "http://localhost:5173"으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->