### PR TITLE
공통 예외 응답 추가

### DIFF
--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/exception/ExceptionType.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/exception/ExceptionType.java
@@ -11,9 +11,11 @@ import static org.springframework.http.HttpStatus.*;
 public enum ExceptionType {
 
     // Common
-    UNEXPECTED_SERVER_ERROR(INTERNAL_SERVER_ERROR,"C001","예상치 못한 에러 발생"),
-    BINDING_ERROR(BAD_REQUEST,"C002","바인딩시 에러 발생"),
-    ESSENTIAL_FIELD_MISSING_ERROR(NO_CONTENT , "C003","필수적인 필드 부재"),
+    UNEXPECTED_SERVER_ERROR(INTERNAL_SERVER_ERROR,"C001","예상치 못한 서버 오류가 발생했습니다."),
+    BINDING_ERROR(BAD_REQUEST,"C002","요청 데이터 변환 과정에서 오류가 발생했습니다."),
+    ESSENTIAL_FIELD_MISSING_ERROR(NO_CONTENT , "C003","필수 필드를 누락했습니다."),
+    INVALID_ENDPOINT(NOT_FOUND, "C004", "잘못된 API URI로 요청했습니다."),
+    INVALID_HTTP_METHOD(METHOD_NOT_ALLOWED, "C005","잘못된 HTTP 메서드로 요청했습니다."),
 
     // Member
     MEMBER_NOT_FOUND(NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/exception/GlobalExceptionHandler.java
@@ -1,38 +1,72 @@
 package kr.ac.kumoh.d138.JobForeigner.global.exception;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RequiredArgsConstructor
 @Slf4j
-@RestControllerAdvice(annotations = {RestController.class}, basePackages = {"kr.ac.kumoh.d138.JobForeigner"})
+@Hidden
+@RestControllerAdvice
 public class GlobalExceptionHandler {
-
     @ExceptionHandler(BusinessException.class)
-    public ResponseEntity<ResponseBody<Void>> businessException(BusinessException e) {
+    public ResponseEntity<ResponseBody<Void>> handleBusinessException(BusinessException e) {
         ExceptionType exceptionType = e.getExceptionType();
         return ResponseEntity.status(exceptionType.getStatus())
                 .body(ResponseUtil.createFailureResponse(exceptionType));
 
     }
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ResponseBody<Void>> methodArgumentNotValidException(MethodArgumentNotValidException e){
-        String customMessage=e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+    public ResponseEntity<ResponseBody<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
+        String customMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
         return ResponseEntity
                 .status(ExceptionType.BINDING_ERROR.getStatus())
                 .body(ResponseUtil.createFailureResponse(ExceptionType.BINDING_ERROR, customMessage));
     }
 
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ResponseBody<Void>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.error("HttpMessageNotReadableException : {}", e.getMessage());
+        return ResponseEntity
+                .status(ExceptionType.BINDING_ERROR.getStatus())
+                .body(ResponseUtil.createFailureResponse(ExceptionType.BINDING_ERROR));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ResponseBody<Void>> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+        return ResponseEntity
+                .status(ExceptionType.INVALID_HTTP_METHOD.getStatus())
+                .body(ResponseUtil.createFailureResponse(ExceptionType.INVALID_HTTP_METHOD));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ResponseBody<Void>> handleNotFound(NoResourceFoundException e) {
+        return ResponseEntity
+                .status(ExceptionType.INVALID_ENDPOINT.getStatus())
+                .body(ResponseUtil.createFailureResponse(ExceptionType.INVALID_ENDPOINT));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ResponseBody<Void>> handleAccessDeniedException(AccessDeniedException e) {
+        log.error("AccessDeniedException : {}", e.getMessage());
+        return ResponseEntity
+                .status(ExceptionType.ACCESS_DENIED.getStatus())
+                .body(ResponseUtil.createFailureResponse(ExceptionType.ACCESS_DENIED));
+    }
+
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ResponseBody<Void>> exception(Exception e){
+    public ResponseEntity<ResponseBody<Void>> handleException(Exception e){
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ResponseUtil.createFailureResponse(ExceptionType.UNEXPECTED_SERVER_ERROR));


### PR DESCRIPTION
## What is this PR?🔍
- 공통 예외 응답을 추가합니다.
- `@Hidden` 애너테이션을 적용해 Swagger가 공통 응답 핸들러를 무시하도록 합니다.

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 잘못된 API URI 및 HTTP 메서드 요청에 대한 예외 처리가 추가되었습니다.
  * 특정 예외 상황(메시지 읽기 불가, 허용되지 않은 메서드, 리소스 미존재, 접근 거부)에 대한 상세한 예외 응답이 제공됩니다.

* **버그 수정**
  * 기존 공통 예외 메시지가 더 명확하게 개선되었습니다.

* **문서화**
  * 글로벌 예외 처리기가 API 문서에서 제외되었습니다.

* **스타일**
  * 예외 처리 메서드 명명 규칙이 일관되게 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->