### PR TITLE
[BUG] JobPost, Scrap, Notification API 명세 오류 해결

### DIFF
--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/api/JobPostApi.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/api/JobPostApi.java
@@ -64,13 +64,18 @@ public interface JobPostApi {
     )
     @SwaggerApiResponses(
             success = @SwaggerApiSuccessResponse(
-                    description = "채용공고 조회 성공"
+                    description = "채용공고 조회 성공",
+                    responsePage = JobPostResponseDto.class
             )
     )
     ResponseEntity<ResponseBody<GlobalPageResponse<JobPostResponseDto>>> showJobPost(
-            @Parameter(description = "기업명 검색") @RequestParam(required = false) String companyName,
-            @Parameter(description = "지역 검색") @RequestParam(required = false) String region,
-            @Parameter(description = "직종 검색") @RequestParam(required = false) String jobType,
+            @Parameter(description = "기업명 검색 키워드")
+            @RequestParam(required = false) String companyName,
+            @Parameter(description = "지역 검색 키워드")
+            @RequestParam(required = false) String region,
+            @Parameter(description = "직종 검색 키워드")
+            @RequestParam(required = false) String jobType,
+            @Parameter(description = "페이징 정보 (기본 크기: 12, 정렬: companyName)")
             @PageableDefault(size = 12, sort = "companyName") Pageable pageable
     );
 
@@ -80,14 +85,16 @@ public interface JobPostApi {
     )
     @SwaggerApiResponses(
             success = @SwaggerApiSuccessResponse(
-                    description = "채용공고 상세 조회 성공"
+                    description = "채용공고 상세 조회 성공",
+                    response = JobPostDetailResponseDto.class
             ),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.JOBPOST_NOT_FOUND)
             }
     )
     ResponseEntity<ResponseBody<JobPostDetailResponseDto>> showJobPostDetail(
-            @Parameter(description = "채용공고 ID") @PathVariable Long id,
+            @Parameter(description = "채용공고 ID", required = true)
+            @PathVariable Long id,
             @AuthenticationPrincipal Long memberId
     );
 
@@ -97,7 +104,8 @@ public interface JobPostApi {
     )
     @SwaggerApiResponses(
             success = @SwaggerApiSuccessResponse(
-                    description = "채용공고 수정 성공"
+                    description = "채용공고 수정 성공",
+                    response = UpdateJobPostResponseDto.class
             ),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.JOBPOST_NOT_FOUND),
@@ -105,7 +113,8 @@ public interface JobPostApi {
             }
     )
     ResponseEntity<ResponseBody<UpdateJobPostResponseDto>> updateJobPost(
-            @Parameter(description = "채용공고 ID") @PathVariable Long id,
+            @Parameter(description = "채용공고 ID", required = true)
+            @PathVariable Long id,
             @Valid @RequestBody JobPostRequestDto jobPostRequestDto
     );
 
@@ -122,7 +131,8 @@ public interface JobPostApi {
             }
     )
     ResponseEntity<ResponseBody<String>> deleteJobPost(
-            @Parameter(description = "채용공고 ID") @PathVariable Long id
+            @Parameter(description = "채용공고 ID", required = true)
+            @PathVariable Long id
     );
 
     @Operation(
@@ -142,8 +152,10 @@ public interface JobPostApi {
             }
     )
     ResponseEntity<ResponseBody<String>> applyToJobPost(
-            @Parameter(description = "채용공고 ID") @PathVariable Long jobPostId,
+            @Parameter(description = "채용공고 ID", required = true)
+            @PathVariable Long jobPostId,
             @AuthenticationPrincipal Long memberId,
-            @Parameter(description = "이력서 ID") @PathVariable Long resumeId
+            @Parameter(description = "이력서 ID", required = true)
+            @PathVariable Long resumeId
     );
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/api/NotificationApi.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/api/NotificationApi.java
@@ -10,7 +10,6 @@ import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.job.dto.response.NotificationResponseDto;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,13 +24,13 @@ public interface NotificationApi {
     )
     @SwaggerApiResponses(
             success = @SwaggerApiSuccessResponse(
-                    description = "읽지 않은 알림 개수 조회 성공"
+                    description = "읽지 않은 알림 개수 조회 성공",
+                    response = Integer.class
             ),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.MEMBER_NOT_FOUND)
             }
     )
-    @PreAuthorize("isAuthenticated()")
     ResponseEntity<ResponseBody<Integer>> getUnreadCount(
             @AuthenticationPrincipal Long memberId
     );
@@ -42,13 +41,13 @@ public interface NotificationApi {
     )
     @SwaggerApiResponses(
             success = @SwaggerApiSuccessResponse(
-                    description = "알림 조회 성공"
+                    description = "알림 조회 성공",
+                    response = NotificationResponseDto[].class
             ),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.MEMBER_NOT_FOUND)
             }
     )
-    @PreAuthorize("isAuthenticated()")
     ResponseEntity<ResponseBody<List<NotificationResponseDto>>> getRecentNotification(
             @AuthenticationPrincipal Long memberId
     );
@@ -59,7 +58,8 @@ public interface NotificationApi {
     )
     @SwaggerApiResponses(
             success = @SwaggerApiSuccessResponse(
-                    description = "알림 읽음 처리 성공"
+                    description = "알림 읽음 처리 성공",
+                    response = NotificationResponseDto.class
             ),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.MEMBER_NOT_FOUND),
@@ -67,9 +67,9 @@ public interface NotificationApi {
                     @SwaggerApiFailedResponse(ExceptionType.ACCESS_DENIED)
             }
     )
-    @PreAuthorize("isAuthenticated()")
     ResponseEntity<ResponseBody<NotificationResponseDto>> checkReadNotification(
-            @Parameter(description = "알림 ID") @PathVariable Long notificationId,
+            @Parameter(description = "알림 ID", required = true)
+            @PathVariable Long notificationId,
             @AuthenticationPrincipal Long memberId
     );
 
@@ -87,9 +87,9 @@ public interface NotificationApi {
                     @SwaggerApiFailedResponse(ExceptionType.ACCESS_DENIED)
             }
     )
-    @PreAuthorize("isAuthenticated()")
     ResponseEntity<ResponseBody<Void>> deleteNotification(
-            @Parameter(description = "알림 ID") @PathVariable Long notificationId,
+            @Parameter(description = "알림 ID", required = true)
+            @PathVariable Long notificationId,
             @AuthenticationPrincipal Long memberId
     );
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/controller/JobPostController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/controller/JobPostController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import kr.ac.kumoh.d138.JobForeigner.global.response.GlobalPageResponse;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil;
+import kr.ac.kumoh.d138.JobForeigner.job.api.JobPostApi;
 import kr.ac.kumoh.d138.JobForeigner.job.dto.request.JobPostRequestDto;
 import kr.ac.kumoh.d138.JobForeigner.job.dto.request.JobTempPostRequestDto;
 import kr.ac.kumoh.d138.JobForeigner.job.dto.response.JobPostDetailResponseDto;
@@ -23,7 +24,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/job-posts")
-public class JobPostController {
+public class JobPostController implements JobPostApi {
 
     private final JobPostService jobPostService;
 

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/controller/NotificationController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/controller/NotificationController.java
@@ -3,6 +3,7 @@ package kr.ac.kumoh.d138.JobForeigner.job.controller;
 
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil;
+import kr.ac.kumoh.d138.JobForeigner.job.api.NotificationApi;
 import kr.ac.kumoh.d138.JobForeigner.job.dto.response.NotificationResponseDto;
 import kr.ac.kumoh.d138.JobForeigner.job.service.NotificationService;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,7 @@ import java.util.List;
 @RequestMapping("/api/v1/notifications")
 @RequiredArgsConstructor
 @Slf4j
-public class NotificationController {
+public class NotificationController implements NotificationApi {
 
     private final NotificationService alarmService;
 

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/scrap/api/ScrapApi.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/scrap/api/ScrapApi.java
@@ -10,7 +10,6 @@ import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.scrap.dto.ScrapResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 
@@ -25,7 +24,8 @@ public interface ScrapApi {
     )
     @SwaggerApiResponses(
             success = @SwaggerApiSuccessResponse(
-                    description = "스크랩 토글 성공"
+                    description = "스크랩 토글 성공",
+                    response = ScrapResponse.class
             ),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.MEMBER_NOT_FOUND),
@@ -33,7 +33,6 @@ public interface ScrapApi {
                     @SwaggerApiFailedResponse(ExceptionType.ACCESS_DENIED)
             }
     )
-    @PreAuthorize("isAuthenticated()")
     ResponseEntity<ResponseBody<ScrapResponse>> toggleScrap(
             @AuthenticationPrincipal Long memberId,
             @Parameter(description = "채용공고 ID", required = true)

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/scrap/controller/ScrapController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/scrap/controller/ScrapController.java
@@ -2,6 +2,7 @@ package kr.ac.kumoh.d138.JobForeigner.scrap.controller;
 
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil;
+import kr.ac.kumoh.d138.JobForeigner.scrap.api.ScrapApi;
 import kr.ac.kumoh.d138.JobForeigner.scrap.dto.ScrapResponse;
 import kr.ac.kumoh.d138.JobForeigner.scrap.service.ScrapService;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/scrap")
-public class ScrapController {
+public class ScrapController implements ScrapApi {
 
     private final ScrapService scrapService;
 


### PR DESCRIPTION


## What is this PR?🔍
- closed #53 

> API 문서화 개선 및 코드 구조 정리를 통한 유지보수성 향상

## Changes💻

- **JobPost API 개선**
  - Swagger 문서화 강화 (파라미터 설명 상세화, response 타입 명시)
  - API 파라미터에 `required = true` 속성 추가
  - JobPostController에 JobPostApi 인터페이스 구현

- **Notification API 개선** 
  - Swagger 응답 타입 명시 (`response` 속성 추가)
  - 불필요한 `@PreAuthorize` 어노테이션 제거 (Spring Security 설정으로 대체)
  - NotificationController에 NotificationApi 인터페이스 구현

- **Scrap API 개선**
  - Swagger 응답 타입 명시
  - `@PreAuthorize` 어노테이션 제거
  - ScrapController에 ScrapApi 인터페이스 구현

## Technical Details 🔧

### API 문서화 개선사항
- 모든 API 응답에 대한 타입 정보 추가
- 파라미니터 설명 더 구체적으로 작성
- 필수 파라미터 명시적 표시

### 코드 구조 개선사항
- Controller 클래스들이 각각의 API 인터페이스를 구현하도록 변경
- 일관된 코드 구조 유지를 위한 리팩토링


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * Swagger API 문서의 응답 타입 및 파라미터 설명이 명확하게 개선되었습니다.
  * 일부 엔드포인트의 기본 페이지 크기 및 정렬 방식에 대한 설명이 추가되었습니다.

* **리팩터**
  * 여러 컨트롤러가 관련 API 인터페이스를 명시적으로 구현하도록 변경되었습니다.

* **스타일**
  * Swagger 응답 설명의 포맷이 일관성 있게 수정되었습니다.

* **기타**
  * 일부 API에서 인증 관련 어노테이션이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->