### PR TITLE
권한 확인이 되지 않는 문제 수정, 필터에서 BusinessException 처리하도록 수정, API 호출 추적 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	// Web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 
 	// Database
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/config/security/SecurityConfig.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/config/security/SecurityConfig.java
@@ -1,12 +1,12 @@
 package kr.ac.kumoh.d138.JobForeigner.global.config.security;
 
-import kr.ac.kumoh.d138.JobForeigner.global.jwt.authentication.JwtAuthenticationProvider;
 import kr.ac.kumoh.d138.JobForeigner.global.jwt.filter.JwtAuthenticationFilter;
+import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionHandlerFilter;
+import kr.ac.kumoh.d138.JobForeigner.member.domain.MemberType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -19,40 +19,44 @@ import org.springframework.web.cors.CorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final CorsConfigurationSource corsConfigurationSource;
+
+    private final ExceptionHandlerFilter exceptionHandlerFilter;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
     private final AccessDeniedHandler customAccessDeniedHandler;
     private final AuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
-    public SecurityFilterChain filterChainPermitAll(HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
-        return defaultSecurity(http, authenticationManager)
-                // 일시적으로 모든 URL에 대해 권한 확인을 시행하지 않음
-                .authorizeHttpRequests(req ->
-                        req.anyRequest().permitAll())
-                .build();
-    }
-
-    public HttpSecurity defaultSecurity(HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
+    public SecurityFilterChain defaultSecurity(HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .httpBasic(AbstractHttpConfigurer::disable)
+                .anonymous(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .rememberMe(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
+
+                .addFilterBefore(exceptionHandlerFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
+
+                // authorizeHttpRequests의 URI는 필터 단에서 차단되어 exceptionHandling에 의해 예외가 처리되지만,
+                // @PreAuthorized, @PostAuthorized의 경우 메서드 호출 직전에 차단되어 GlobalExceptionHandler에 의해 예외가 처리됩니다.
+                .authorizeHttpRequests(req -> req
+                        .requestMatchers("/api/v1/admin/**").hasAnyRole(MemberType.ADMIN.name())
+                        .anyRequest().permitAll())
+
                 .exceptionHandling(ex -> ex
-                    .accessDeniedHandler(customAccessDeniedHandler)
-                    .authenticationEntryPoint(customAuthenticationEntryPoint))
-                .addFilterAfter(new JwtAuthenticationFilter(authenticationManager), UsernamePasswordAuthenticationFilter.class)
-                .cors(cors -> cors.configurationSource(corsConfigurationSource));
-    }
+                        .accessDeniedHandler(customAccessDeniedHandler)
+                        .authenticationEntryPoint(customAuthenticationEntryPoint))
 
-    @Bean
-    public AuthenticationManager authenticationManager(JwtAuthenticationProvider jwtAuthenticationProvider) {
-        return new ProviderManager(jwtAuthenticationProvider);
+                .build();
     }
-
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/exception/ExceptionHandlerFilter.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/exception/ExceptionHandlerFilter.java
@@ -1,0 +1,32 @@
+package kr.ac.kumoh.d138.JobForeigner.global.exception;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+    private final HandlerExceptionResolver handlerExceptionResolver;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (BusinessException e) {
+            handlerExceptionResolver.resolveException(request, response, null, e);
+        } catch (Exception e) {
+            log.error("{}", e.getMessage(), e);
+            handlerExceptionResolver.resolveException(request, response, null, e);
+        }
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -63,6 +64,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ExceptionType.ACCESS_DENIED.getStatus())
                 .body(ResponseUtil.createFailureResponse(ExceptionType.ACCESS_DENIED));
+    }
+
+    @ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
+    public ResponseEntity<ResponseBody<Void>> handleAuthenticationCredentialsNotFoundException(AuthenticationCredentialsNotFoundException e) {
+        return ResponseEntity
+                .status(ExceptionType.NEED_AUTHORIZED.getStatus())
+                .body(ResponseUtil.createFailureResponse(ExceptionType.NEED_AUTHORIZED));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/jwt/annotation/CurrentMemberId.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/jwt/annotation/CurrentMemberId.java
@@ -1,0 +1,12 @@
+package kr.ac.kumoh.d138.JobForeigner.global.jwt.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentMemberId {
+    boolean required() default true;
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/jwt/annotation/CurrentMemberIdArgumentResolver.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/jwt/annotation/CurrentMemberIdArgumentResolver.java
@@ -1,0 +1,47 @@
+package kr.ac.kumoh.d138.JobForeigner.global.jwt.annotation;
+
+import kr.ac.kumoh.d138.JobForeigner.global.exception.BusinessException;
+import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.authentication.JwtAuthentication;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Slf4j
+@Component
+public class CurrentMemberIdArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentMemberId.class) && Long.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        CurrentMemberId annotation = parameter.getParameterAnnotation(CurrentMemberId.class);
+        boolean required = annotation == null || annotation.required();
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication instanceof JwtAuthentication jwtAuthentication) {
+            Object principal = jwtAuthentication.getPrincipal();
+            if (principal != null) return principal;
+        }
+
+        if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
+            if (required) {
+                throw new BusinessException(ExceptionType.NEED_AUTHORIZED);
+            }
+            return null;
+        }
+
+        log.error("알 수 없는 Authentication 타입입니다: {}", authentication.getClass());
+        throw new IllegalArgumentException("@CurrentMemberId는 JWT 기반의 JwtAuthentication 또는 AnonymousAuthenticationToken 타입만 지원합니다.");
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/jwt/annotation/CurrentMemberIdConfig.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/jwt/annotation/CurrentMemberIdConfig.java
@@ -1,0 +1,19 @@
+package kr.ac.kumoh.d138.JobForeigner.global.jwt.annotation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class CurrentMemberIdConfig implements WebMvcConfigurer {
+    private final CurrentMemberIdArgumentResolver resolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(resolver);
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/jwt/config/JwtConfig.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/jwt/config/JwtConfig.java
@@ -1,5 +1,6 @@
 package kr.ac.kumoh.d138.JobForeigner.global.jwt.config;
 
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.authentication.JwtAuthenticationProvider;
 import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.access.AccessTokenProvider;
 import kr.ac.kumoh.d138.JobForeigner.global.jwt.properties.JwtProperties;
 import kr.ac.kumoh.d138.JobForeigner.global.jwt.properties.KeyProperties;
@@ -8,12 +9,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
 
 @Configuration
 @RequiredArgsConstructor
 @EnableConfigurationProperties({ KeyProperties.class, JwtProperties.class })
 public class JwtConfig {
-
     @Bean
     public AccessTokenProvider accessTokenProvider(KeyProperties keyProperties, JwtProperties jwtProperties) {
         return new AccessTokenProvider(keyProperties, jwtProperties);
@@ -24,4 +26,8 @@ public class JwtConfig {
         return new RefreshTokenProvider(jwtProperties);
     }
 
+    @Bean
+    public AuthenticationManager authenticationManager(JwtAuthenticationProvider jwtAuthenticationProvider) {
+        return new ProviderManager(jwtAuthenticationProvider);
+    }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/jwt/filter/JwtAuthenticationFilter.java
@@ -7,12 +7,14 @@ import jakarta.servlet.http.HttpServletResponse;
 import kr.ac.kumoh.d138.JobForeigner.global.exception.BusinessException;
 import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
 import kr.ac.kumoh.d138.JobForeigner.global.jwt.authentication.JwtUnauthenticatedToken;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.TokenUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -20,31 +22,26 @@ import java.io.IOException;
 import java.util.Optional;
 
 @Slf4j
+@Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-
-    private static final String BEARER_PREFIX = "Bearer ";
-
     private final AuthenticationManager authenticationManager;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        if (isAnonymousRequest(request)) {
-            filterChain.doFilter(request, response);
-            return;
-        }
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        return authorizationHeader == null;
+    }
 
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         JwtUnauthenticatedToken unauthenticatedToken = new JwtUnauthenticatedToken(resolveAccessToken(request)
                 .orElseThrow(() -> new BusinessException(ExceptionType.JWT_NOT_EXIST)));
+
         Authentication authentication = authenticationManager.authenticate(unauthenticatedToken);
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         filterChain.doFilter(request, response);
-    }
-
-    private boolean isAnonymousRequest(HttpServletRequest request) {
-        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-        return authorizationHeader == null;
     }
 
     private Optional<String> resolveAccessToken(HttpServletRequest request) {
@@ -54,11 +51,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return Optional.empty();
         }
 
-        if (!authorizationHeader.startsWith(BEARER_PREFIX)) {
+        if (!authorizationHeader.startsWith(TokenUtils.BEARER_PREFIX)) {
             return Optional.empty();
         }
 
-        return Optional.of(authorizationHeader.substring(BEARER_PREFIX.length()));
+        return Optional.of(authorizationHeader.substring(TokenUtils.BEARER_PREFIX.length()));
     }
-
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/log/ControllerLoggingAspect.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/log/ControllerLoggingAspect.java
@@ -1,0 +1,48 @@
+package kr.ac.kumoh.d138.JobForeigner.global.log;
+
+import jakarta.servlet.http.HttpServletRequest;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.authentication.JwtAuthentication;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.lang.reflect.Method;
+
+@Aspect
+@Component
+@Slf4j
+public class ControllerLoggingAspect {
+    @Around("within(@org.springframework.web.bind.annotation.RestController *)")
+    public Object logControllerMethods(ProceedingJoinPoint joinPoint) throws Throwable {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
+        String requestUri = request.getRequestURI();
+
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+        Method method = methodSignature.getMethod();
+
+        String className = joinPoint.getSignature().getDeclaringTypeName();
+        String methodName = method.getName();
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Object principal = null;
+        if (authentication instanceof JwtAuthentication jwtAuthentication) {
+            principal = jwtAuthentication.getPrincipal();
+        }
+        Long memberId = principal != null ? (Long) principal : 0;
+
+        log.info("API 호출 시작 [memberId={}, requestUri={}, requestClassAndMethod={}::{}]", memberId, requestUri, className, methodName);
+
+        Object result = joinPoint.proceed();
+
+        log.info("API 호출 완료 [memberId={}, requestUri={}, requestClassAndMethod={}::{}]", memberId, requestUri, className, methodName);
+
+        return result;
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/api/JobPostApi.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/api/JobPostApi.java
@@ -8,6 +8,7 @@ import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiFailedRespo
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiResponses;
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiSuccessResponse;
 import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.annotation.CurrentMemberId;
 import kr.ac.kumoh.d138.JobForeigner.global.response.GlobalPageResponse;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.job.dto.request.JobPostRequestDto;
@@ -18,7 +19,6 @@ import kr.ac.kumoh.d138.JobForeigner.job.dto.response.UpdateJobPostResponseDto;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "채용공고 API", description = "채용공고 관련 API")
@@ -88,7 +88,7 @@ public interface JobPostApi {
     )
     ResponseEntity<ResponseBody<JobPostDetailResponseDto>> showJobPostDetail(
             @Parameter(description = "채용공고 ID") @PathVariable Long id,
-            @AuthenticationPrincipal Long memberId
+            @CurrentMemberId Long memberId
     );
 
     @Operation(
@@ -143,7 +143,7 @@ public interface JobPostApi {
     )
     ResponseEntity<ResponseBody<String>> applyToJobPost(
             @Parameter(description = "채용공고 ID") @PathVariable Long jobPostId,
-            @AuthenticationPrincipal Long memberId,
+            @CurrentMemberId Long memberId,
             @Parameter(description = "이력서 ID") @PathVariable Long resumeId
     );
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/api/NotificationApi.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/api/NotificationApi.java
@@ -7,11 +7,10 @@ import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiFailedRespo
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiResponses;
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiSuccessResponse;
 import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.annotation.CurrentMemberId;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.job.dto.response.NotificationResponseDto;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -31,9 +30,8 @@ public interface NotificationApi {
                     @SwaggerApiFailedResponse(ExceptionType.MEMBER_NOT_FOUND)
             }
     )
-    @PreAuthorize("isAuthenticated()")
     ResponseEntity<ResponseBody<Integer>> getUnreadCount(
-            @AuthenticationPrincipal Long memberId
+            @CurrentMemberId Long memberId
     );
 
     @Operation(
@@ -48,9 +46,8 @@ public interface NotificationApi {
                     @SwaggerApiFailedResponse(ExceptionType.MEMBER_NOT_FOUND)
             }
     )
-    @PreAuthorize("isAuthenticated()")
     ResponseEntity<ResponseBody<List<NotificationResponseDto>>> getRecentNotification(
-            @AuthenticationPrincipal Long memberId
+            @CurrentMemberId Long memberId
     );
 
     @Operation(
@@ -67,10 +64,9 @@ public interface NotificationApi {
                     @SwaggerApiFailedResponse(ExceptionType.ACCESS_DENIED)
             }
     )
-    @PreAuthorize("isAuthenticated()")
     ResponseEntity<ResponseBody<NotificationResponseDto>> checkReadNotification(
             @Parameter(description = "알림 ID") @PathVariable Long notificationId,
-            @AuthenticationPrincipal Long memberId
+            @CurrentMemberId Long memberId
     );
 
     @Operation(
@@ -87,9 +83,8 @@ public interface NotificationApi {
                     @SwaggerApiFailedResponse(ExceptionType.ACCESS_DENIED)
             }
     )
-    @PreAuthorize("isAuthenticated()")
     ResponseEntity<ResponseBody<Void>> deleteNotification(
             @Parameter(description = "알림 ID") @PathVariable Long notificationId,
-            @AuthenticationPrincipal Long memberId
+            @CurrentMemberId Long memberId
     );
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/controller/JobPostController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/controller/JobPostController.java
@@ -1,6 +1,7 @@
 package kr.ac.kumoh.d138.JobForeigner.job.controller;
 
 import jakarta.validation.Valid;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.annotation.CurrentMemberId;
 import kr.ac.kumoh.d138.JobForeigner.global.response.GlobalPageResponse;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil;
@@ -16,7 +17,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -67,7 +67,7 @@ public class JobPostController {
      */
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ResponseBody<JobPostDetailResponseDto>> showJobPostDetail(@PathVariable Long id, @AuthenticationPrincipal Long memberId){
+    public ResponseEntity<ResponseBody<JobPostDetailResponseDto>> showJobPostDetail(@PathVariable Long id, @CurrentMemberId Long memberId){
         JobPostDetailResponseDto jobPostDetail = jobPostService.getJobPostDetail(id, memberId);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(jobPostDetail));
     }
@@ -96,7 +96,7 @@ public class JobPostController {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ResponseBody<String>> applyToJobPost(
             @PathVariable Long jobPostId,
-            @AuthenticationPrincipal Long memberId,
+            @CurrentMemberId Long memberId,
             @PathVariable Long resumeId) {
         jobPostService.applyToJobPost(jobPostId, memberId, resumeId);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse("채용공고 지원 완료"));

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/controller/NotificationController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/job/controller/NotificationController.java
@@ -1,6 +1,6 @@
 package kr.ac.kumoh.d138.JobForeigner.job.controller;
 
-
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.annotation.CurrentMemberId;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil;
 import kr.ac.kumoh.d138.JobForeigner.job.dto.response.NotificationResponseDto;
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,7 +26,7 @@ public class NotificationController {
      */
     @GetMapping
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ResponseBody<Integer>> getUnreadCount(@AuthenticationPrincipal Long memberId){
+    public ResponseEntity<ResponseBody<Integer>> getUnreadCount(@CurrentMemberId Long memberId){
         int count = alarmService.getUnreadCount(memberId);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(count));
     }
@@ -37,7 +36,7 @@ public class NotificationController {
      */
     @GetMapping("/recent")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ResponseBody<List<NotificationResponseDto>>> getRecentNotification(@AuthenticationPrincipal Long memberId){
+    public ResponseEntity<ResponseBody<List<NotificationResponseDto>>> getRecentNotification(@CurrentMemberId Long memberId){
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(alarmService.getRecentNotification(memberId)));
     }
 
@@ -46,7 +45,7 @@ public class NotificationController {
      */
     @PostMapping("/{notificationId}")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ResponseBody<NotificationResponseDto>> checkReadNotification(@PathVariable Long notificationId, @AuthenticationPrincipal Long memberId){
+    public ResponseEntity<ResponseBody<NotificationResponseDto>> checkReadNotification(@PathVariable Long notificationId, @CurrentMemberId Long memberId){
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(alarmService.checkReadNotification(memberId, notificationId)));
     }
 
@@ -55,7 +54,7 @@ public class NotificationController {
      */
     @DeleteMapping("/{notificationId}")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ResponseBody<Void>> deleteNotification(@PathVariable Long notificationId, @AuthenticationPrincipal Long memberId){
+    public ResponseEntity<ResponseBody<Void>> deleteNotification(@PathVariable Long notificationId, @CurrentMemberId Long memberId){
         alarmService.deleteNotification(notificationId, memberId);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
     }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/api/AuthApi.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/api/AuthApi.java
@@ -8,11 +8,11 @@ import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiFailedRespo
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiResponses;
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiSuccessResponse;
 import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.annotation.CurrentMemberId;
 import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.TokenUtils;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.member.dto.request.SignInRequest;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -51,7 +51,7 @@ public interface AuthApi {
                     description = "로그아웃이 성공적으로 완료되어 리프레시 토큰이 삭제되었습니다."
             )
     )
-    ResponseEntity<ResponseBody<Void>> signOut(@AuthenticationPrincipal Long memberId,
+    ResponseEntity<ResponseBody<Void>> signOut(@CurrentMemberId Long memberId,
                                                @Parameter(description = "리프레시 토큰")
                                                @CookieValue(TokenUtils.COOKIE_NAME_REFRESH_TOKEN) Cookie refreshToken,
                                                HttpServletResponse response);
@@ -71,6 +71,6 @@ public interface AuthApi {
                     @SwaggerApiFailedResponse(ExceptionType.MEMBER_NOT_FOUND)
             }
     )
-    ResponseEntity<ResponseBody<Void>> delete(@AuthenticationPrincipal Long memberId,
+    ResponseEntity<ResponseBody<Void>> delete(@CurrentMemberId Long memberId,
                                               HttpServletResponse response);
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/api/MemberApi.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/api/MemberApi.java
@@ -2,7 +2,6 @@ package kr.ac.kumoh.d138.JobForeigner.member.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -12,16 +11,14 @@ import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiFailedRespo
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiResponses;
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiSuccessResponse;
 import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.annotation.CurrentMemberId;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.member.dto.request.MemberProfileRequest;
 import kr.ac.kumoh.d138.JobForeigner.member.dto.request.ProfileImageRequest;
 import kr.ac.kumoh.d138.JobForeigner.member.dto.response.MemberProfileResponse;
-import kr.ac.kumoh.d138.JobForeigner.resume.dto.response.ResumeResponse;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 public interface MemberApi {
@@ -41,8 +38,8 @@ public interface MemberApi {
                     @SwaggerApiFailedResponse(ExceptionType.MEMBER_NOT_FOUND)
             }
     )
-    public ResponseEntity<ResponseBody<MemberProfileResponse>> getMyProfile(
-            @AuthenticationPrincipal Long memberId);
+    ResponseEntity<ResponseBody<MemberProfileResponse>> getMyProfile(
+            @CurrentMemberId Long memberId);
 
 
     @Operation(
@@ -59,9 +56,9 @@ public interface MemberApi {
                     @SwaggerApiFailedResponse(ExceptionType.MEMBER_NOT_FOUND)
             }
     )
-    public ResponseEntity<ResponseBody<Void>> updateMyProfile(
+    ResponseEntity<ResponseBody<Void>> updateMyProfile(
             @RequestBody @Valid MemberProfileRequest request,
-            @AuthenticationPrincipal Long memberId);
+            @CurrentMemberId Long memberId);
 
 
     @Operation(
@@ -79,11 +76,11 @@ public interface MemberApi {
                     @SwaggerApiFailedResponse(ExceptionType.FILE_SYSTEM_SAVE_FAILED)
             }
     )
-    public ResponseEntity<ResponseBody<Void>> updateProfileImage(
+    ResponseEntity<ResponseBody<Void>> updateProfileImage(
             @Parameter(
                     description = "프로필 이미지 파일",
                     content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
             )
             @ModelAttribute ProfileImageRequest request,
-            @AuthenticationPrincipal Long memberId);
+            @CurrentMemberId Long memberId);
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/controller/AuthController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/controller/AuthController.java
@@ -2,6 +2,7 @@ package kr.ac.kumoh.d138.JobForeigner.member.controller;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.annotation.CurrentMemberId;
 import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.TokenUtils;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil;
@@ -11,7 +12,7 @@ import kr.ac.kumoh.d138.JobForeigner.member.service.AuthService;
 import kr.ac.kumoh.d138.JobForeigner.token.dto.JwtPair;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -41,7 +42,8 @@ public class AuthController implements AuthApi {
      * 외국인 및 기업 사용자 로그아웃 API
      */
     @DeleteMapping("/sign-out")
-    public ResponseEntity<ResponseBody<Void>> signOut(@AuthenticationPrincipal Long memberId,
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseBody<Void>> signOut(@CurrentMemberId Long memberId,
                                                       @CookieValue(TokenUtils.COOKIE_NAME_REFRESH_TOKEN) Cookie refreshToken,
                                                       HttpServletResponse response) {
         authService.signOut(refreshToken.getValue());
@@ -53,7 +55,8 @@ public class AuthController implements AuthApi {
      * 외국인 및 기업 사용자 회원탈퇴 API
      */
     @DeleteMapping("/me")
-    public ResponseEntity<ResponseBody<Void>> delete(@AuthenticationPrincipal Long memberId,
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseBody<Void>> delete(@CurrentMemberId Long memberId,
                                                      HttpServletResponse response) {
         authService.delete(memberId);
         tokenUtils.deleteRefreshToken(response);

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/controller/MemberController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/controller/MemberController.java
@@ -1,7 +1,7 @@
 package kr.ac.kumoh.d138.JobForeigner.member.controller;
 
 import jakarta.validation.Valid;
-import kr.ac.kumoh.d138.JobForeigner.global.jwt.authentication.JwtAuthentication;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.annotation.CurrentMemberId;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.member.api.MemberApi;
 import kr.ac.kumoh.d138.JobForeigner.member.dto.request.MemberProfileRequest;
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import static kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil.createSuccessResponse;
@@ -29,15 +28,14 @@ public class MemberController implements MemberApi {
 //    // 사용자의 프로필 정보 반환
 //    @GetMapping("/{memberId}")
 //    @PreAuthorize("isAuthenticated()")
-//    public ResponseEntity<ResponseBody<MemberProfileResponse>> getUserProfile(@PathVariable Long memberId) {
+//    public ResponseEntity<ResponseBody<MemberProfileResponse>> getUserProfile(@CurrentMemberId Long memberId) {
 //        return ResponseEntity.ok(createSuccessResponse(memberService.getMemberProfile(memberId)));
 //    }
 
     // 자신의 프로필 정보 반환
     @GetMapping("/me")
-    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ResponseBody<MemberProfileResponse>> getMyProfile(
-            @AuthenticationPrincipal Long memberId) {
+            @CurrentMemberId Long memberId) {
         return ResponseEntity.ok(createSuccessResponse(memberService.getMemberProfile(memberId)));
     }
 
@@ -46,7 +44,7 @@ public class MemberController implements MemberApi {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ResponseBody<Void>> updateMyProfile(
             @RequestBody @Valid MemberProfileRequest request,
-            @AuthenticationPrincipal Long memberId){
+            @CurrentMemberId Long memberId){
         memberService.updateMemberProfile(memberId, request);
         return ResponseEntity.ok(createSuccessResponse());
     }
@@ -57,7 +55,7 @@ public class MemberController implements MemberApi {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ResponseBody<Void>> updateProfileImage(
             @ModelAttribute ProfileImageRequest request,
-            @AuthenticationPrincipal Long memberId){
+            @CurrentMemberId Long memberId){
         memberService.updateProfileImage(request, memberId);
         return ResponseEntity.ok(createSuccessResponse());
     }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/api/ResumeApi.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/api/ResumeApi.java
@@ -11,6 +11,7 @@ import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiFailedRespo
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiResponses;
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiSuccessResponse;
 import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.annotation.CurrentMemberId;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.resume.dto.request.ResumeRequest;
 import kr.ac.kumoh.d138.JobForeigner.resume.dto.response.ResumeResponse;
@@ -21,7 +22,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
@@ -43,7 +43,6 @@ public interface ResumeApi {
                     @SwaggerApiFailedResponse(ExceptionType.FILE_SYSTEM_SAVE_FAILED)
             }
     )
-
     ResponseEntity<ResponseBody<Void>> createResume(
             @Parameter(
                     description = "이력서 정보",
@@ -58,7 +57,7 @@ public interface ResumeApi {
             @RequestPart(required = false) MultipartFile image,
 
             @Parameter(hidden = true)
-            @AuthenticationPrincipal Long memberId
+            @CurrentMemberId Long memberId
     );
 
 
@@ -80,7 +79,7 @@ public interface ResumeApi {
     )
     ResponseEntity<ResponseBody<ResumeResponse>> getResume(
             @Parameter(hidden = true)
-            @AuthenticationPrincipal Long memberId,
+            @CurrentMemberId Long memberId,
 
             @Parameter(description = "조회할 이력서 ID", example = "1")
             @PathVariable Long resumeId
@@ -104,7 +103,7 @@ public interface ResumeApi {
     )
     ResponseEntity<ResponseBody<Page<ResumeResponse>>> getAllResumes(
             @Parameter(hidden = true)
-            @AuthenticationPrincipal Long memberId,
+            @CurrentMemberId Long memberId,
 
             @ParameterObject
             @PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC)
@@ -144,7 +143,7 @@ public interface ResumeApi {
             @RequestPart MultipartFile image,
 
             @Parameter(hidden = true)
-            @AuthenticationPrincipal Long memberId,
+            @CurrentMemberId Long memberId,
 
             @Parameter(description = "수정할 이력서 ID", example = "1")
             @PathVariable Long resumeId
@@ -171,7 +170,7 @@ public interface ResumeApi {
             @PathVariable Long resumeId,
 
             @Parameter(hidden = true)
-            @AuthenticationPrincipal Long memberId
+            @CurrentMemberId Long memberId
     );
 
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/controller/ResumeController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/resume/controller/ResumeController.java
@@ -1,5 +1,6 @@
 package kr.ac.kumoh.d138.JobForeigner.resume.controller;
 
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.annotation.CurrentMemberId;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.resume.api.ResumeApi;
 import kr.ac.kumoh.d138.JobForeigner.resume.domain.Resume;
@@ -14,12 +15,10 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-
-import static kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil.createSuccessResponse;
+import static kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil.*;
 
 @RestController
 @RequestMapping("/api/v1/resumes")
@@ -34,7 +33,7 @@ public class ResumeController implements ResumeApi {
     public ResponseEntity<ResponseBody<Void>> createResume(
             @RequestPart ResumeRequest resumeRequest,
             @RequestPart(required = false) MultipartFile image,
-            @AuthenticationPrincipal Long memberId) {
+            @CurrentMemberId Long memberId) {
         resumeService.createResume(resumeRequest, image, memberId);
         return ResponseEntity.ok(createSuccessResponse());
     }
@@ -45,7 +44,7 @@ public class ResumeController implements ResumeApi {
     @GetMapping("/{resumeId}")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ResponseBody<ResumeResponse>> getResume(
-            @AuthenticationPrincipal Long memberId,
+            @CurrentMemberId Long memberId,
             @PathVariable Long resumeId) {
         Resume resume = resumeService.getResume(memberId, resumeId);
         return ResponseEntity.ok(createSuccessResponse(ResumeResponse.toResumeResponse(resume)));
@@ -55,7 +54,7 @@ public class ResumeController implements ResumeApi {
     @GetMapping()
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ResponseBody<Page<ResumeResponse>>> getAllResumes
-            (@AuthenticationPrincipal Long memberId,
+            (@CurrentMemberId Long memberId,
              @PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable) {
         Page<ResumeResponse> resumeResponses = resumeService.getAllResume(memberId, pageable);
         return ResponseEntity.ok(createSuccessResponse(resumeResponses));
@@ -66,7 +65,7 @@ public class ResumeController implements ResumeApi {
     public ResponseEntity<ResponseBody<ResumeResponse>> updateResume(
         @RequestPart ResumeRequest resumeRequest,
         @RequestPart MultipartFile image,
-        @AuthenticationPrincipal Long memberId,
+        @CurrentMemberId Long memberId,
         @PathVariable Long resumeId
     ) {
         ResumeResponse response = resumeService.updateResume(resumeRequest, image, memberId, resumeId);
@@ -76,7 +75,7 @@ public class ResumeController implements ResumeApi {
     // 사용자의 이력서 삭제
     @DeleteMapping("/{resumeId}")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ResponseBody<Void>> deleteResume(@PathVariable Long resumeId, @AuthenticationPrincipal Long memberId){
+    public ResponseEntity<ResponseBody<Void>> deleteResume(@PathVariable Long resumeId, @CurrentMemberId Long memberId){
         resumeService.deleteResume(resumeId, memberId);
         return ResponseEntity.ok(createSuccessResponse());
     }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/scrap/api/ScrapApi.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/scrap/api/ScrapApi.java
@@ -7,11 +7,11 @@ import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiFailedRespo
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiResponses;
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiSuccessResponse;
 import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.annotation.CurrentMemberId;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.scrap.dto.ScrapResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "스크랩 API", description = "채용공고 스크랩 관련 API")
@@ -35,7 +35,7 @@ public interface ScrapApi {
     )
     @PreAuthorize("isAuthenticated()")
     ResponseEntity<ResponseBody<ScrapResponse>> toggleScrap(
-            @AuthenticationPrincipal Long memberId,
+            @CurrentMemberId Long memberId,
             @Parameter(description = "채용공고 ID", required = true)
             @PathVariable Long jobPostId
     );

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/scrap/controller/ScrapController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/scrap/controller/ScrapController.java
@@ -1,5 +1,6 @@
 package kr.ac.kumoh.d138.JobForeigner.scrap.controller;
 
+import kr.ac.kumoh.d138.JobForeigner.global.jwt.annotation.CurrentMemberId;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil;
 import kr.ac.kumoh.d138.JobForeigner.scrap.dto.ScrapResponse;
@@ -7,7 +8,6 @@ import kr.ac.kumoh.d138.JobForeigner.scrap.service.ScrapService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +23,7 @@ public class ScrapController {
     @PostMapping("/{jobPostId}")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ResponseBody<ScrapResponse>> toggleScrap(
-            @AuthenticationPrincipal Long memberId,
+            @CurrentMemberId Long memberId,
             @PathVariable Long jobPostId
     ) {
         ScrapResponse dto = scrapService.toggleScrap(memberId, jobPostId);


### PR DESCRIPTION
## What is this PR?🔍
- `@PreAuthorized("isAuthenticated()")`를 적용했음에도 미인증 사용자가 API를 인증 사용자처럼 호출할 수 있던 문제를 수정합니다.
- `@AuthenticationPrincipal` 사용 시 미인증 사용자가 API를 호출하면 null이 반환되는 문제를 해결합니다.
- 개발 서버에서 어떤 API가 호출되고, 실패했는지를 추적하기 위해 컨트롤러 실행 전후로 로그를 남깁니다.

## Changes💻
**1️⃣ 권한 확인이 되지 않는 문제 수정**
- `SecurityConfig`에 `@EnableMethodSecurity`를 적용하여 메서드 단위 권한 확인을 진행할 수 있도록 합니다.
- 권한 확인이 필요 없는 API에 `@PreAuthorized` 또는 `@PostAuthorized`가 적용돼 있다면 확인해 주시기 바랍니다.

**2️⃣ 필터가 비즈니스 예외를 처리할 수 있도록 수정**
- `ExceptionHandlerFilter`를 추가하여 `BusinessException`인 경우 GlobalExceptionHandler가 예외를 처리하도록 합니다.

**3️⃣ `@AuthenticationPrincipal` 대신 `@CurrentMemberId` 애너테이션 사용**
- `@AuthenticationPrincipal`은 미인증 사용자가 API를 호출하면 null이 반환돼 예외 `IllegalArgumentException`가 발생하는 문제가 있습니다. 이를 위해서는 `@PreAuthorized("isAuthenticated()")`와 함께 사용해야 합니다.
- 다만, 미인증 사용자이더라도 어떤 API는 호출이 필요할 수 있으므로 선택적으로 사용할 수 있도록 하기 위해 `@CurrentMemberId` 애너테이션을 추가합니다.
- 이 애너테이션은 `required` 속성으로 필수 여부를 지정할 수 있으며 기본 값은 필수(`true`)입니다.
- 적용 예는 [0ef2d71955898f10d3063b7df7a6e4d0d7260aed](https://github.com/th-D138/Backend-JobForeigner/commit/0ef2d71955898f10d3063b7df7a6e4d0d7260aed)를 참조하십시오.

**4️⃣ API 호출 추적 추가**
- 프론트엔드에서 예외 발생 시 어떤 API가 호출되었는지 표시되지 않아 잘 모르는 경우가 많습니다. 어떤 API가 호출되어 예외가 발생했는지 확인할 수 있도록 AOP 라이브러리와 API 호출 추적 Aspect를 추가합니다.

## ScreenShot📷
|![image](https://github.com/user-attachments/assets/cf792597-e9ad-42c6-abe5-671bd816f270)|![image](https://github.com/user-attachments/assets/3ad22ba2-19f6-4f64-8d75-3bb09cbba72d)|
|:---:|:---:|
|**1️⃣ 권한 확인이 되지 않는 문제 수정**|**2️⃣ 필터가 비즈니스 예외를 처리할 수 있도록 수정**|

|![image](https://github.com/user-attachments/assets/582d17f3-0942-4942-b448-545e6c91f6b7)|![image](https://github.com/user-attachments/assets/a52696f2-545f-4a62-9390-8c46df7b656e)|
|:---:|:---:|
|**3️⃣ `@AuthenticationPrincipal` 대신 `@CurrentMemberId` 애너테이션 사용**|**4️⃣ API 호출 추적 추가**|