### PR TITLE
이메일 주소 인증 수정 및 이메일 주소 변경 추가, API 문서 수정

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -86,7 +86,10 @@ jobs:
       - name: Clean up old container and image
         run: |
           docker rm -f ${{ vars.CONTAINER_NAME }} || true
-          docker rmi ${{ needs.build.outputs.image-tag }} || true
+          docker images "ghcr.io/${{ github.repository }}" \
+          --format "{{.Repository}}:{{.Tag}}" \
+          | grep -v "${{ needs.build.outputs.image-tag }}" \
+          | xargs -r docker rmi -f || true
 
       # 새로운 이미지로 새로운 컨테이너 생성하여 실행
       - name: Run New Container

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/api/AuthEmailApi.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/api/AuthEmailApi.java
@@ -1,9 +1,10 @@
 package kr.ac.kumoh.d138.JobForeigner.email.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import kr.ac.kumoh.d138.JobForeigner.email.dto.request.ResendAuthMailRequest;
+import kr.ac.kumoh.d138.JobForeigner.email.dto.request.SendAuthMailRequest;
+import kr.ac.kumoh.d138.JobForeigner.email.dto.request.VerifyAuthCodeRequest;
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiFailedResponse;
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiResponses;
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiSuccessResponse;
@@ -11,36 +12,31 @@ import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 
+@Tag(name = "이메일 주소 인증 API", description = "이메일 주소 인증 관련 API")
 public interface AuthEmailApi {
     @Operation(
-            summary = "이메일 주소 인증 메일 재발송",
-            description = "미인증된 회원이 이메일 주소 인증 메일 재발송 요청 시 인증 메일을 재발송합니다."
+            summary = "이메일 주소 인증 메일 발송",
+            description = "이메일 주소 인증 메일 발송 요청 시 인증 메일을 발송합니다."
     )
     @SwaggerApiResponses(
             success = @SwaggerApiSuccessResponse(
-                    description = "이메일 주소 인증 메일 재발송 성공"
-            ),
-            errors = {
-                    @SwaggerApiFailedResponse(ExceptionType.MEMBER_NOT_FOUND),
-                    @SwaggerApiFailedResponse(ExceptionType.EMAIL_ALREADY_VERIFIED)
-            }
+                    description = "이메일 주소 인증 메일 발송 성공"
+            )
     )
-    ResponseEntity<ResponseBody<Void>> resendAuthMail(@RequestBody @Valid ResendAuthMailRequest resendAuthMailRequest);
+    ResponseEntity<ResponseBody<Void>> sendAuthMail(@RequestBody @Valid SendAuthMailRequest sendAuthMailRequest);
 
     @Operation(
             summary = "이메일 주소 인증",
-            description = "발급된 인증 코드를 포함하는 URL로 접속 시 이메일 주소 인증을 완료합니다."
+            description = "이메일 주소와 발급된 인증 코드를 요청으로 보내면 이메일 주소 인증을 완료합니다."
     )
     @SwaggerApiResponses(
             success = @SwaggerApiSuccessResponse(
                     description = "이메일 주소 인증 성공"
             ),
             errors = {
-                    @SwaggerApiFailedResponse(ExceptionType.AUTH_CODE_INVALID),
-                    @SwaggerApiFailedResponse(ExceptionType.MEMBER_NOT_FOUND)
+                    @SwaggerApiFailedResponse(ExceptionType.AUTH_CODE_INVALID)
             }
     )
-    ResponseEntity<ResponseBody<Void>> verify(@RequestParam("code") @NotBlank String code);
+    ResponseEntity<ResponseBody<Void>> verify(@RequestBody @Valid VerifyAuthCodeRequest verifyAuthCodeRequest);
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/controller/AuthEmailController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/controller/AuthEmailController.java
@@ -1,9 +1,9 @@
 package kr.ac.kumoh.d138.JobForeigner.email.controller;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import kr.ac.kumoh.d138.JobForeigner.email.api.AuthEmailApi;
-import kr.ac.kumoh.d138.JobForeigner.email.dto.request.ResendAuthMailRequest;
+import kr.ac.kumoh.d138.JobForeigner.email.dto.request.SendAuthMailRequest;
+import kr.ac.kumoh.d138.JobForeigner.email.dto.request.VerifyAuthCodeRequest;
 import kr.ac.kumoh.d138.JobForeigner.email.service.AuthEmailService;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil;
@@ -12,7 +12,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,15 +20,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthEmailController implements AuthEmailApi {
     private final AuthEmailService authEmailService;
 
-    @PostMapping("/auth/resend")
-    public ResponseEntity<ResponseBody<Void>> resendAuthMail(@RequestBody @Valid ResendAuthMailRequest resendAuthMailRequest) {
-        authEmailService.sendMail(resendAuthMailRequest.email());
+    @PostMapping("/auth/send")
+    public ResponseEntity<ResponseBody<Void>> sendAuthMail(@RequestBody @Valid SendAuthMailRequest sendAuthMailRequest) {
+        authEmailService.sendMail(sendAuthMailRequest.email());
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
     }
 
     @PostMapping("/auth/verify")
-    public ResponseEntity<ResponseBody<Void>> verify(@RequestParam("code") @NotBlank String code) {
-        authEmailService.verifyEmail(code);
+    public ResponseEntity<ResponseBody<Void>> verify(@RequestBody @Valid VerifyAuthCodeRequest verifyAuthCodeRequest) {
+        authEmailService.verifyEmail(verifyAuthCodeRequest);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
     }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/domain/AuthCode.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/domain/AuthCode.java
@@ -1,44 +1,17 @@
 package kr.ac.kumoh.d138.JobForeigner.email.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-
-@Entity
-@Table(name = "auth_code")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuthCode {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @Column(name = "email", unique = true, nullable = false)
+    private String code;
     private String email;
 
-    @Column(name = "code", unique = true, nullable = false)
-    private String code;
-
-    @Column(name = "expired_at", nullable = false) // TODO: expired_at이 경과된 레코드를 삭제하는 작업 필요
-    private LocalDateTime expiredAt;
-
-    public AuthCode(String email, String code) {
+    public AuthCode(String code, String email) {
+        this.code = code;
         this.email = email;
-        this.code = code;
-        this.expiredAt = LocalDateTime.now().plusHours(24L);
-    }
-
-    public void reissue(String code) {
-        this.code = code;
-        this.expiredAt = LocalDateTime.now().plusHours(24L);
     }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/dto/request/SendAuthMailRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/dto/request/SendAuthMailRequest.java
@@ -1,9 +1,11 @@
 package kr.ac.kumoh.d138.JobForeigner.email.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
-public record ResendAuthMailRequest(
+public record SendAuthMailRequest(
+    @Schema(description = "이메일 주소", example = "park@duck.com")
     @NotBlank(message = "이메일은 필수 입력 항목입니다.")
     @Email(message = "올바른 이메일 형식이 아닙니다.")
     String email

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/dto/request/VerifyAuthCodeRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/dto/request/VerifyAuthCodeRequest.java
@@ -13,7 +13,7 @@ public record VerifyAuthCodeRequest(
 
     @Schema(description = "인증 코드", example = "123456")
     @NotBlank(message = "인증 코드는 필수 입력 항목입니다.")
-    @Pattern(regexp = "^\\d{6}$")
+    @Pattern(regexp = "^\\d{6}$", message = "만료되거나 잘못된 인증 코드입니다.")
     String code
 ) {
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/dto/request/VerifyAuthCodeRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/dto/request/VerifyAuthCodeRequest.java
@@ -1,0 +1,19 @@
+package kr.ac.kumoh.d138.JobForeigner.email.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record VerifyAuthCodeRequest(
+    @Schema(description = "이메일 주소", example = "park@duck.com")
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    String email,
+
+    @Schema(description = "인증 코드", example = "123456")
+    @NotBlank(message = "인증 코드는 필수 입력 항목입니다.")
+    @Pattern(regexp = "^\\d{6}$")
+    String code
+) {
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/repository/AuthCodeRepository.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/repository/AuthCodeRepository.java
@@ -1,11 +1,13 @@
 package kr.ac.kumoh.d138.JobForeigner.email.repository;
 
 import kr.ac.kumoh.d138.JobForeigner.email.domain.AuthCode;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface AuthCodeRepository extends JpaRepository<AuthCode, Long> {
-    Optional<AuthCode> findByEmail(String email);
-    Optional<AuthCode> findByCode(String code);
+public interface AuthCodeRepository {
+    void save(final AuthCode authCode);
+
+    Optional<AuthCode> findById(final String authCode);
+
+    void deleteById(final String authCode);
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/repository/AuthCodeRepositoryImpl.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/repository/AuthCodeRepositoryImpl.java
@@ -1,0 +1,58 @@
+package kr.ac.kumoh.d138.JobForeigner.email.repository;
+
+import kr.ac.kumoh.d138.JobForeigner.email.domain.AuthCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+public class AuthCodeRepositoryImpl implements AuthCodeRepository {
+    private static final String KEY_PREFIX = "authCode";
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ValueOperations<String, String> valueOperations;
+
+    private final int AUTH_CODE_EXPIRED_IN;
+
+    public AuthCodeRepositoryImpl(RedisTemplate<String, String> redisTemplate,
+                                  @Value("${job-foreigner.mail.auth.expired-in}") int authCodeExpiredIn) {
+        this.redisTemplate = redisTemplate;
+        this.valueOperations = redisTemplate.opsForValue();
+
+        this.AUTH_CODE_EXPIRED_IN = authCodeExpiredIn;
+    }
+
+    @Override
+    public void save(AuthCode authCode) {
+        String key = getKey(authCode.getCode());
+        valueOperations.set(key, authCode.getEmail());
+        redisTemplate.expire(key, AUTH_CODE_EXPIRED_IN, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public Optional<AuthCode> findById(String code) {
+        String key = getKey(code);
+
+        String email = valueOperations.get(key);
+        if (Objects.isNull(email)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new AuthCode(code, email));
+    }
+
+    @Override
+    public void deleteById(String code) {
+        String key = getKey(code);
+        redisTemplate.delete(key);
+    }
+
+    private String getKey(final String code) {
+        return KEY_PREFIX + ":" + code;
+    }
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/service/AuthEmailService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/service/AuthEmailService.java
@@ -60,7 +60,7 @@ public class AuthEmailService {
 
             return builder.toString();
         } catch (NoSuchAlgorithmException e) {
-            log.debug("이메일 주소 인증 메일의 인증 코드 생성에 실패했습니다: {}", e.getMessage());
+            log.error("이메일 주소 인증 메일의 인증 코드 생성에 실패했습니다: {}", e.getMessage());
             throw new BusinessException(ExceptionType.UNEXPECTED_SERVER_ERROR);
         }
     }
@@ -76,7 +76,7 @@ public class AuthEmailService {
             Template template = Mustache.compiler().compile(reader);
             return template.execute(model);
         } catch (Exception e) {
-            log.error("템플릿 읽기에 실패하여 인증 코드 {}의 인증 메일이 발송되지 않습니다: {}", code, e.getMessage());
+            log.error("템플릿 읽기에 실패하여 인증 메일이 발송되지 않습니다: {}", e.getMessage());
             throw new BusinessException(ExceptionType.UNEXPECTED_SERVER_ERROR);
         }
     }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/service/AuthEmailService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/service/AuthEmailService.java
@@ -3,11 +3,10 @@ package kr.ac.kumoh.d138.JobForeigner.email.service;
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Template;
 import kr.ac.kumoh.d138.JobForeigner.email.domain.AuthCode;
+import kr.ac.kumoh.d138.JobForeigner.email.dto.request.VerifyAuthCodeRequest;
 import kr.ac.kumoh.d138.JobForeigner.email.repository.AuthCodeRepository;
 import kr.ac.kumoh.d138.JobForeigner.global.exception.BusinessException;
 import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
-import kr.ac.kumoh.d138.JobForeigner.member.domain.Member;
-import kr.ac.kumoh.d138.JobForeigner.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,16 +15,19 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.Reader;
-import java.time.LocalDateTime;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.Map;
-import java.util.UUID;
+import java.util.Random;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AuthEmailService {
-    private final MemberRepository memberRepository;
+    private static final String SUBJECT_AUTH_CODE = "AUTH_CODE";
+    private static final int LENGTH = 6;
+
     private final AuthCodeRepository authCodeRepository;
 
     private final EmailSendService sendService;
@@ -36,37 +38,37 @@ public class AuthEmailService {
     @Value("${job-foreigner.mail.auth.base-url}")
     private String baseUrl;
 
-    @Value("${job-foreigner.mail.auth.verify-path}")
-    private String verifyPath;
-
     @Transactional
     public void sendMail(String email) {
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new BusinessException(ExceptionType.MEMBER_NOT_FOUND));
+        String code = createCode();
+        String subject = authEmailSubject.replace(SUBJECT_AUTH_CODE, code);
+        String htmlContent = createContent(code);
 
-        // 이미 이메일 인증을 받았다면 새로운 인증 코드를 받을 수 없도록 함
-        if (member.isVerified()) {
-            throw new BusinessException(ExceptionType.EMAIL_ALREADY_VERIFIED);
-        }
-
-        String code = UUID.randomUUID().toString();
-
-        // 인증 코드가 데이터베이스에 이미 생성돼 있다면 갱신하고, 없다면 새롭게 만듦
-        authCodeRepository.findByEmail(member.getEmail())
-                .ifPresentOrElse(entity -> entity.reissue(code), () -> {
-                    AuthCode entity = new AuthCode(member.getEmail(), code);
-                    authCodeRepository.save(entity);
-                });
-
-        String htmlContent = createContent(member.getName(), code);
-        sendService.sendMail(member.getEmail(), authEmailSubject, htmlContent);
+        AuthCode authCode = new AuthCode(code, email);
+        authCodeRepository.save(authCode);
+        sendService.sendMail(email, subject, htmlContent);
     }
 
-    private String createContent(String name, String code) {
+    private String createCode() {
+        try {
+            Random random = SecureRandom.getInstanceStrong();
+            StringBuilder builder = new StringBuilder();
+
+            for (int i = 0; i < LENGTH; ++i) {
+                builder.append(random.nextInt(10));
+            }
+
+            return builder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            log.debug("이메일 주소 인증 메일의 인증 코드 생성에 실패했습니다: {}", e.getMessage());
+            throw new BusinessException(ExceptionType.UNEXPECTED_SERVER_ERROR);
+        }
+    }
+
+    private String createContent(String code) {
         Map<String, Object> model = Map.of(
-                "name", name,
                 "baseUrl", baseUrl,
-                "verifyUrl", baseUrl + verifyPath + code
+                "code", code
         );
 
         try (Reader reader = new MustacheResourceTemplateLoader("templates/", ".html")
@@ -74,25 +76,20 @@ public class AuthEmailService {
             Template template = Mustache.compiler().compile(reader);
             return template.execute(model);
         } catch (Exception e) {
-            log.error("템플릿 읽기에 실패하여 {}님께 인증 메일이 발송되지 않습니다: {}", name, e.getMessage());
+            log.error("템플릿 읽기에 실패하여 인증 코드 {}의 인증 메일이 발송되지 않습니다: {}", code, e.getMessage());
             throw new BusinessException(ExceptionType.UNEXPECTED_SERVER_ERROR);
         }
     }
 
     @Transactional
-    public void verifyEmail(String code) {
-        AuthCode authCode = authCodeRepository.findByCode(code)
+    public void verifyEmail(VerifyAuthCodeRequest request) {
+        AuthCode authCode = authCodeRepository.findById(request.code())
                 .orElseThrow(() -> new BusinessException(ExceptionType.AUTH_CODE_INVALID));
 
-        // 인증 링크를 누른 일자가 만료 일자 이후라면 인증을 수행할 수 없도록 함
-        if (LocalDateTime.now().isAfter(authCode.getExpiredAt())) {
+        if (!request.email().equals(authCode.getEmail())) {
             throw new BusinessException(ExceptionType.AUTH_CODE_INVALID);
         }
 
-        Member member = memberRepository.findByEmail(authCode.getEmail())
-                .orElseThrow(() -> new BusinessException(ExceptionType.MEMBER_NOT_FOUND));
-        member.setVerified();
-
-        authCodeRepository.deleteById(authCode.getId());
+        authCodeRepository.deleteById(authCode.getCode());
     }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/service/EmailSendService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/email/service/EmailSendService.java
@@ -27,7 +27,7 @@ public class EmailSendService {
         } catch (MessagingException e) {
             log.warn("이메일 전송 중 SMTP 서버 오류 발생: {}", e.getMessage());
         } catch (Exception e) {
-            log.error("이메일 전송 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+            log.error("이메일 전송 중 예상치 못한 오류 발생: {}", e.getMessage());
         }
     }
 

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/jwt/annotation/CurrentMemberId.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/jwt/annotation/CurrentMemberId.java
@@ -1,5 +1,7 @@
 package kr.ac.kumoh.d138.JobForeigner.global.jwt.annotation;
 
+import io.swagger.v3.oas.annotations.Parameter;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,6 +9,7 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
 public @interface CurrentMemberId {
     boolean required() default true;
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/log/ControllerLoggingAspect.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/log/ControllerLoggingAspect.java
@@ -19,7 +19,11 @@ import java.lang.reflect.Method;
 @Component
 @Slf4j
 public class ControllerLoggingAspect {
-    @Around("within(@org.springframework.web.bind.annotation.RestController *)")
+    @Around(
+            "within(kr.ac.kumoh.d138.JobForeigner..controller..*Controller) " +
+                    "&& !within(io.swagger.v3.oas.annotations..*) " +
+                    "&& !within(org.springdoc..*)"
+    )
     public Object logControllerMethods(ProceedingJoinPoint joinPoint) throws Throwable {
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
         String requestUri = request.getRequestURI();

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/api/AuthApi.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/api/AuthApi.java
@@ -2,8 +2,11 @@ package kr.ac.kumoh.d138.JobForeigner.member.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiFailedResponse;
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiResponses;
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiSuccessResponse;
@@ -11,12 +14,14 @@ import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
 import kr.ac.kumoh.d138.JobForeigner.global.jwt.annotation.CurrentMemberId;
 import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.TokenUtils;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
+import kr.ac.kumoh.d138.JobForeigner.member.dto.request.ChangeEmailRequest;
 import kr.ac.kumoh.d138.JobForeigner.member.dto.request.SignInRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestBody;
 
 public interface AuthApi {
+    @Tag(name = "인증 API", description = "인증 관련 API")
     @Operation(
             summary = "로그인",
             description = "사용자 로그인을 진행해 액세스 토큰과 리프레시 토큰을 획득할 수 있습니다."
@@ -29,16 +34,13 @@ public interface AuthApi {
                     @SwaggerApiFailedResponse(
                             value = ExceptionType.MEMBER_INFO_INVALID,
                             description = "요청으로 보낸 사용자 정보와 서버에 등록된 사용자 정보가 일치하지 않아 발생합니다."
-                    ),
-                    @SwaggerApiFailedResponse(
-                            value = ExceptionType.EMAIL_VERIFICATION_REQUIRED,
-                            description = "사용자가 회원가입 후 이메일 주소 인증을 완료하지 않아 발생합니다."
                     )
             }
     )
     ResponseEntity<ResponseBody<Void>> signIn(@RequestBody SignInRequest signInRequest,
                                               HttpServletResponse response);
 
+    @Tag(name = "인증 API", description = "인증 관련 API")
     @Operation(
             summary = "로그아웃",
             description = """
@@ -56,6 +58,22 @@ public interface AuthApi {
                                                @CookieValue(TokenUtils.COOKIE_NAME_REFRESH_TOKEN) Cookie refreshToken,
                                                HttpServletResponse response);
 
+    @Tag(name = "계정 API", description = "계정 관련 API")
+    @Operation(
+            summary = "이메일 주소 변경",
+            description = """
+                    이메일 주소를 변경합니다. 이메일 인증 진행 후 이메일 주소를 변경해야 합니다.
+                    """
+    )
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "이메일 주소 변경이 성공적으로 완료되었습니다."
+            )
+    )
+    ResponseEntity<ResponseBody<Void>> changeEmail(@CurrentMemberId Long memberId,
+                                                   @Valid ChangeEmailRequest changeEmailRequest);
+
+    @Tag(name = "계정 API", description = "계정 관련 API")
     @Operation(
             summary = "회원탈퇴",
             description = """

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/api/AuthApi.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/api/AuthApi.java
@@ -2,7 +2,6 @@ package kr.ac.kumoh.d138.JobForeigner.member.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -24,7 +23,7 @@ public interface AuthApi {
     @Tag(name = "인증 API", description = "인증 관련 API")
     @Operation(
             summary = "로그인",
-            description = "사용자 로그인을 진행해 액세스 토큰과 리프레시 토큰을 획득할 수 있습니다."
+            description = "외국인 및 기업 사용자 로그인을 진행해 액세스 토큰과 리프레시 토큰을 획득할 수 있습니다."
     )
     @SwaggerApiResponses(
             success = @SwaggerApiSuccessResponse(
@@ -44,7 +43,7 @@ public interface AuthApi {
     @Operation(
             summary = "로그아웃",
             description = """
-                    로그아웃을 진행해 리프레시 토큰을 삭제할 수 있습니다.<br>
+                    외국인 및 기업 사용자 로그아웃을 진행해 리프레시 토큰을 삭제할 수 있습니다.<br>
                     액세스 토큰이 만료되지 않으면 로그인이 유효할 수 있습니다.
                     """
     )
@@ -62,7 +61,7 @@ public interface AuthApi {
     @Operation(
             summary = "이메일 주소 변경",
             description = """
-                    이메일 주소를 변경합니다. 이메일 인증 진행 후 이메일 주소를 변경해야 합니다.
+                    외국인 및 기업 사용자 이메일 주소를 변경합니다. 이메일 인증 진행 후 이메일 주소를 변경해야 합니다.
                     """
     )
     @SwaggerApiResponses(
@@ -77,7 +76,7 @@ public interface AuthApi {
     @Operation(
             summary = "회원탈퇴",
             description = """
-                    회원탈퇴를 진행해 회원 정보와 리프레시 토큰을 삭제할 수 있습니다.<br>
+                    외국인 및 기업 사용자 회원탈퇴를 진행해 회원 정보와 리프레시 토큰을 삭제할 수 있습니다.<br>
                     액세스 토큰이 만료되지 않으면 인증 오류가 발생할 수 있습니다.
                     """
     )

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/api/CompanyMemberApi.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/api/CompanyMemberApi.java
@@ -1,6 +1,7 @@
 package kr.ac.kumoh.d138.JobForeigner.member.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiFailedResponse;
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiResponses;
@@ -13,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
+@Tag(name = "계정 API", description = "계정 관련 API")
 public interface CompanyMemberApi {
     @Operation(
             summary = "사업자등록번호 검증",

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/api/ForeignerMemberApi.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/api/ForeignerMemberApi.java
@@ -1,6 +1,7 @@
 package kr.ac.kumoh.d138.JobForeigner.member.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiFailedResponse;
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiResponses;
@@ -12,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
+@Tag(name = "계정 API", description = "계정 관련 API")
 public interface ForeignerMemberApi {
     @Operation(
             summary = "외국인 사용자 회원가입",

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/controller/AuthController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/controller/AuthController.java
@@ -2,11 +2,13 @@ package kr.ac.kumoh.d138.JobForeigner.member.controller;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import kr.ac.kumoh.d138.JobForeigner.global.jwt.annotation.CurrentMemberId;
 import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.TokenUtils;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseUtil;
 import kr.ac.kumoh.d138.JobForeigner.member.api.AuthApi;
+import kr.ac.kumoh.d138.JobForeigner.member.dto.request.ChangeEmailRequest;
 import kr.ac.kumoh.d138.JobForeigner.member.dto.request.SignInRequest;
 import kr.ac.kumoh.d138.JobForeigner.member.service.AuthService;
 import kr.ac.kumoh.d138.JobForeigner.token.dto.JwtPair;
@@ -15,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -48,6 +51,17 @@ public class AuthController implements AuthApi {
                                                       HttpServletResponse response) {
         authService.signOut(refreshToken.getValue());
         tokenUtils.deleteRefreshToken(response);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 외국인 및 기업 사용자 이메일 주소 변경 API
+     */
+    @PatchMapping("/me/email")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseBody<Void>> changeEmail(@CurrentMemberId Long memberId,
+                                                          @Valid ChangeEmailRequest changeEmailRequest) {
+        authService.changeEmail(memberId, changeEmailRequest);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/controller/TestMemberController.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/controller/TestMemberController.java
@@ -1,5 +1,7 @@
 package kr.ac.kumoh.d138.JobForeigner.member.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.TokenUtils;
 import kr.ac.kumoh.d138.JobForeigner.global.response.ResponseBody;
@@ -17,10 +19,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/test/members")
 @RequiredArgsConstructor
+@Tag(name = "테스트 API", description = "테스트 관련 API")
 public class TestMemberController {
     private final TestMemberService testMemberService;
     private final TokenUtils tokenUtils;
 
+    @Operation(summary = "기업 사용자 로그인")
     @PostMapping("/sign-up/company")
     public ResponseEntity<ResponseBody<Void>> signUpForCompany(HttpServletResponse response) {
         JwtPair tokens = testMemberService.signUpForCompany();
@@ -28,6 +32,7 @@ public class TestMemberController {
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
     }
 
+    @Operation(summary = "외국인 사용자 로그인")
     @PostMapping("/sign-up/foreigner")
     public ResponseEntity<ResponseBody<Void>> signUpForForeigner(HttpServletResponse response) {
         JwtPair tokens = testMemberService.signUpForForeigner();

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/domain/Member.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/domain/Member.java
@@ -24,7 +24,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE member SET deleted_at = CURRENT_TIMESTAMP WHERE member_id = ?")
-@SQLRestriction(value = "deleted_at is NULL") // TODO: 7일 후 논리적 삭제된 사용자를 물리적으로 삭제하는 cron 작업이 필요
+@SQLRestriction(value = "deleted_at is NULL")
 public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,9 +33,6 @@ public class Member extends BaseEntity {
 
     @Column(name = "name", nullable = false)
     private String name;
-
-    @Column(name = "username", nullable = false, unique = true)
-    private String username;
 
     @Column(name = "password", nullable = false)
     private String password;
@@ -67,7 +64,7 @@ public class Member extends BaseEntity {
     private String profileImageUrl;
 
     @Column(name = "verified", nullable = false)
-    private Boolean isVerified = false;
+    private Boolean isVerified = true;
 
     @Embedded
     @AttributeOverrides({
@@ -80,7 +77,6 @@ public class Member extends BaseEntity {
     @Builder
     public Member(
             @NonNull String name,
-            @NonNull String username,
             @NonNull String password,
             @NonNull MemberType type,
             Long companyId,
@@ -93,7 +89,6 @@ public class Member extends BaseEntity {
             @NonNull Address address
     ) {
         this.name = name;
-        this.username = username;
         this.password = password;
         this.type = type;
         this.companyId = companyId;
@@ -120,11 +115,14 @@ public class Member extends BaseEntity {
   
     public void changeEmail(String email) {
         this.email = email;
-        this.isVerified = false;
     }
 
     public void setVerified() {
         this.isVerified = true;
+    }
+
+    public void unsetVerified() {
+        this.isVerified = false;
     }
 
     public boolean isVerified() {

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/BusinessNumberValidationRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/BusinessNumberValidationRequest.java
@@ -1,5 +1,6 @@
 package kr.ac.kumoh.d138.JobForeigner.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -23,14 +24,20 @@ public class BusinessNumberValidationRequest {
     @NoArgsConstructor
     @Getter
     public static class BusinessInfo {
+        @Schema(description = "사업자등록번호", example = "5138302865")
         @NotBlank(message = "사업자등록번호는 필수 항목입니다.")
         @Pattern(regexp = "^[0-9]{10}$", message = "사업자등록번호는 숫자로만 이루어진 10자리여야 합니다.")
         private String b_no;
+
+        @Schema(description = "개업일자", example = "19780601")
         @NotBlank(message = "개업일자는 필수 항목입니다.")
         @Pattern(regexp = "^[0-9]{8}$", message = "날짜 형식은 숫자로만 이루어진 8자리여야 합니다.")
         private String start_dt;
+
+        @Schema(description = "대표자 성명", example = "곽호상")
         @NotBlank(message = "대표자 성명은 필수 항목입니다.")
         private String p_nm;
+
         // 필수 항목이 아닌 선택 항목은 빈 문자열을 전달
         private String p_nm2 = "";
         private String b_nm = "";

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/ChangeEmailRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/ChangeEmailRequest.java
@@ -1,0 +1,13 @@
+package kr.ac.kumoh.d138.JobForeigner.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ChangeEmailRequest(
+    @Schema(description = "이메일 주소", example = "park@duck.com")
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    String email
+) {
+}

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/CompanySignUpRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/CompanySignUpRequest.java
@@ -1,5 +1,6 @@
 package kr.ac.kumoh.d138.JobForeigner.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -8,29 +9,46 @@ import jakarta.validation.constraints.Pattern;
 import java.time.LocalDate;
 
 public record CompanySignUpRequest(
+        @Schema(description = "담당자 이름")
         @NotBlank(message = "담당자 이름은 필수 입력 항목입니다.")
         String name,
-        @NotBlank(message = "기업 계정 아이디는 필수 입력 항목입니다.")
-        String username,
+
+        @Schema(description = "비밀번호")
         @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
         @Pattern(regexp = "^[\\x20-\\x7E]{8,}$", message = "8자 이상의 알파벳 대소문자, 숫자, 특수문자만 사용할 수 있습니다.")
         String password,
+
         @NotNull(message = "기업 아이디는 필수 입력 항목입니다.")
         Long companyId,
+
+        @Schema(description = "담당자 전화번호")
         @NotBlank(message = "담당자 전화번호는 필수 입력 항목입니다.")
         String phoneNumber,
-        @NotBlank(message = "담당자 이메일은 필수 입력 항목입니다.")
-        @Email(message = "올바른 이메일 형식이 아닙니다.")
+
+        @Schema(description = "담당자 이메일 주소", example = "park@duck.com")
+        @NotBlank(message = "담당자 이메일 주소는 필수 입력 항목입니다.")
+        @Email(message = "올바른 이메일 주소 형식이 아닙니다.")
         String email,
+
+        @Schema(description = "성별")
         @NotBlank(message = "담당자 성별은 필수 입력 항목입니다.")
         @Pattern(regexp = "MALE|FEMALE", message = "성별은 MALE 또는 FEMALE이어야 합니다.")
         String gender,
+
+        @Schema(description = "담당자 생년월일", example = "1978-06-01")
         @NotNull(message = "담당자 생년월일은 필수 입력 항목입니다.")
         LocalDate birthDate,
+
         String profileImageUrl,
+
+        @Schema(description = "기업 주소", example = "경상북도 구미시 대학로 61")
         @NotBlank(message = "기업 주소는 필수 입력 항목입니다.")
         String address,
+
+        @Schema(description = "기업 상세 주소", example = "(양호동)")
         String detailAddress,
+
+        @Schema(description = "기업 우편번호", example = "39177")
         @NotBlank(message = "기업 우편번호는 필수 입력 항목입니다.")
         String zipcode
 ) {

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/ForeignerSignUpRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/ForeignerSignUpRequest.java
@@ -1,5 +1,6 @@
 package kr.ac.kumoh.d138.JobForeigner.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -8,27 +9,43 @@ import jakarta.validation.constraints.Pattern;
 import java.time.LocalDate;
 
 public record ForeignerSignUpRequest(
+        @Schema(description = "이름")
         @NotBlank(message = "이름은 필수 입력 항목입니다.")
         String name,
-        @NotBlank(message = "아이디는 필수 입력 항목입니다.")
-        String username,
+
+        @Schema(description = "비밀번호")
         @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
         @Pattern(regexp = "^[\\x20-\\x7E]{8,}$", message = "8자 이상의 알파벳 대소문자, 숫자, 특수문자만 사용할 수 있습니다.")
         String password,
+
+        @Schema(description = "전화번호")
         @NotBlank(message = "전화번호는 필수 입력 항목입니다.")
         String phoneNumber,
-        @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+
+        @Schema(description = "이메일 주소", example = "park@duck.com")
+        @NotBlank(message = "이메일 주소는 필수 입력 항목입니다.")
         @Email(message = "올바른 이메일 형식이 아닙니다.")
         String email,
+
+        @Schema(description = "성별")
         @NotBlank(message = "성별은 필수 입력 항목입니다.")
         @Pattern(regexp = "MALE|FEMALE", message = "성별은 MALE 또는 FEMALE이어야 합니다.")
         String gender,
+
+        @Schema(description = "생년월일", example = "1978-06-01")
         @NotNull(message = "생년월일은 필수 입력 항목입니다.")
         LocalDate birthDate,
+
         String profileImageUrl,
+
+        @Schema(description = "주소", example = "경상북도 구미시 대학로 61")
         @NotBlank(message = "주소는 필수 입력 항목입니다.")
         String address,
+
+        @Schema(description = "상세 주소", example = "(양호동)")
         String detailAddress,
+
+        @Schema(description = "우편번호", example = "39177")
         @NotBlank(message = "우편번호는 필수 입력 항목입니다.")
         String zipcode
 ) {

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/SignInRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/SignInRequest.java
@@ -1,7 +1,15 @@
 package kr.ac.kumoh.d138.JobForeigner.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
 public record SignInRequest(
+        @Schema(description = "이메일 주소", example = "park@duck.com")
+        @NotBlank(message = "이메일 주소는 필수 입력 항목입니다.")
         String email,
+
+        @Schema(description = "비밀번호")
+        @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
         String password
 ) {
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/AuthService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/AuthService.java
@@ -1,6 +1,5 @@
 package kr.ac.kumoh.d138.JobForeigner.member.service;
 
-import kr.ac.kumoh.d138.JobForeigner.email.service.AuthEmailService;
 import kr.ac.kumoh.d138.JobForeigner.global.exception.BusinessException;
 import kr.ac.kumoh.d138.JobForeigner.global.exception.ExceptionType;
 import kr.ac.kumoh.d138.JobForeigner.global.jwt.JwtClaims;
@@ -9,6 +8,7 @@ import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.access.AccessTokenProvider
 import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.refresh.RefreshTokenData;
 import kr.ac.kumoh.d138.JobForeigner.global.jwt.token.refresh.RefreshTokenProvider;
 import kr.ac.kumoh.d138.JobForeigner.member.domain.Member;
+import kr.ac.kumoh.d138.JobForeigner.member.dto.request.ChangeEmailRequest;
 import kr.ac.kumoh.d138.JobForeigner.member.repository.MemberRepository;
 import kr.ac.kumoh.d138.JobForeigner.token.dto.JwtPair;
 import kr.ac.kumoh.d138.JobForeigner.token.repository.RefreshTokenRepository;
@@ -25,8 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
-
-    private final AuthEmailService authEmailService;
 
     private final AccessTokenProvider accessTokenProvider;
     private final RefreshTokenProvider refreshTokenProvider;
@@ -71,17 +69,16 @@ public class AuthService {
     }
 
     @Transactional
-    public void changeEmail(Long memberId, String email) {
+    public void changeEmail(Long memberId, ChangeEmailRequest changeEmailRequest) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ExceptionType.MEMBER_NOT_FOUND));
 
         // 이미 등록된 이메일인지 확인
-        if (memberRepository.existsByEmail(email)) {
+        if (memberRepository.existsByEmail(changeEmailRequest.email())) {
             throw new BusinessException(ExceptionType.EMAIL_ALREADY_EXISTS);
         }
 
-        // 이메일 변경 및 이메일 주소 인증 메일 발송
-        member.changeEmail(email);
-        authEmailService.sendMail(email);
+        // 이메일 주소 변경
+        member.changeEmail(changeEmailRequest.email());
     }
 }

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/CompanyMemberService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/CompanyMemberService.java
@@ -43,7 +43,6 @@ public class CompanyMemberService {
 
         Member member = Member.builder()
                 .name(req.name())
-                .username(req.username())
                 .password(passwordEncoder.encode(req.password()))
                 .type(MemberType.COMPANY)
                 .companyId(req.companyId())

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/ForeignerMemberService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/ForeignerMemberService.java
@@ -34,7 +34,6 @@ public class ForeignerMemberService {
 
         Member member = Member.builder()
                 .name(req.name())
-                .username(req.username())
                 .password(passwordEncoder.encode(req.password()))
                 .type(MemberType.FOREIGNER)
                 .phoneNumber(req.phoneNumber())

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/TestMemberService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/TestMemberService.java
@@ -48,7 +48,6 @@ public class TestMemberService {
     private final int COMPANY_MONTHLY_TAKE_HOME = 1980000;
 
     private final String MEMBER_NAME = "홍길순";
-    private final String MEMBER_USERNAME = "test";
     private final String MEMBER_PASSWORD = "test!234";
     private final String MEMBER_TYPE_COMPANY = "COMPANY";
     private final String MEMBER_TYPE_FOREIGNER = "FOREIGNER";
@@ -71,7 +70,6 @@ public class TestMemberService {
 
         Member member = Member.builder()
                 .name(MEMBER_NAME)
-                .username(MEMBER_USERNAME)
                 .password(passwordEncoder.encode(MEMBER_PASSWORD))
                 .type(MemberType.valueOf(MEMBER_TYPE_FOREIGNER))
                 .phoneNumber(MEMBER_PHONE_NUMBER)
@@ -111,7 +109,6 @@ public class TestMemberService {
 
         Member member = Member.builder()
                 .name(MEMBER_NAME)
-                .username(MEMBER_USERNAME)
                 .password(passwordEncoder.encode(MEMBER_PASSWORD))
                 .type(MemberType.valueOf(MEMBER_TYPE_COMPANY))
                 .companyId(company.getId())

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/token/api/TokenApi.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/token/api/TokenApi.java
@@ -2,6 +2,7 @@ package kr.ac.kumoh.d138.JobForeigner.token.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import kr.ac.kumoh.d138.JobForeigner.global.config.swagger.SwaggerApiFailedResponse;
@@ -15,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestHeader;
 
+@Tag(name = "인증 API", description = "인증 관련 API")
 public interface TokenApi {
     @Operation(
             summary = "액세스 토큰 및 리프레시 토큰 재발급",

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -42,9 +42,9 @@ spring:
           starttls:
             enable: true
             required: true
-          connectiontimeout: 5000
-          timeout: 15000
-          writetimeout: 5000
+          timeout: 20000
+          connectiontimeout: 20000
+          writetimeout: 20000
 
 springdoc:
   packagesToScan: kr.ac.kumoh.d138.JobForeigner

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -42,9 +42,9 @@ spring:
           starttls:
             enable: true
             required: true
-          connectiontimeout: 5000
-          timeout: 15000
-          writetimeout: 5000
+          connectiontimeout: 20000
+          timeout: 20000
+          writetimeout: 20000
 
 logging:
   level:

--- a/src/main/resources/templates/email/auth/auth-mail.html
+++ b/src/main/resources/templates/email/auth/auth-mail.html
@@ -10,7 +10,7 @@
       <tbody>
         <tr>
           <td>
-            <table style="margin:0 auto;width:60%;padding:0;border-spacing:0">
+            <table style="margin:0 auto;padding:0;border-spacing:0;min-width:50%;max-width:100%;width:calc(230400px — 48000%);max-width:100%;">
               <tbody>
                 <!-- Logo -->
                 <tr>
@@ -29,58 +29,26 @@
                     </h1>
                   </td>
                 </tr>
-                <!-- English -->
+                <!-- Content -->
                 <tr>
-                  <td style="padding-bottom:1rem">
-                    <p style="margin:0;font-size:1rem">Hey {{name}} 👋</p>
+                  <td style="padding-bottom:3rem">
+                    <p style="margin:0;font-size:1rem">Please verify your email address using the code below to complete account setup.</p>
                   </td>
                 </tr>
+                <!-- Authentication Code -->
+                <tr>
+                  <td style="padding-bottom:3rem">
+                    <p style="margin:0;font-size:2rem;font-weight:bold;">
+                      {{code}}
+                    </p>
+                  </td>
+                </tr>
+                <!-- Content -->
                 <tr>
                   <td style="padding-bottom:2rem">
-                    <p style="margin:0;font-size:1rem">Simply click the link below to verify your email address and get started. The link expires in 24 hours.</p>
-                    <p style="margin:0;font-size:1rem">If you haven't registered your email address with JobForeigner, please ignore this email.</p>
-                  </td>
-                </tr>
-                <!-- Button -->
-                <tr>
-                  <td style="padding-bottom:0.5rem">
-                    <a href="{{verifyUrl}}" style="background-color:#9333ea;color:#ffffff;text-decoration:none;padding:0.75rem 1.5rem;font-size:1rem;border-radius:0.375rem;display:inline-block">
-                      Verify my email address
-                    </a>
-                  </td>
-                </tr>
-                <!-- Link -->
-                <tr>
-                  <td style="padding-bottom:2rem">
-                    <p style="margin:0;font-size:0.8rem">Button not working? Paste the following link into your browser: <a href="{{verifyUrl}}">{{verifyUrl}}</a></p>
-                  </td>
-                </tr>
-                <!-- Korean -->
-                <tr>
-                  <td style="padding-bottom:2rem">
-                    <p style="margin:0;font-size:1rem">이메일 주소 인증을 위해 상단의 링크를 클릭해 주세요. 링크는 24시간 이후 만료됩니다.</p>
-                    <p style="margin:0;font-size:1rem">JobForeigner에 이메일 주소를 등록하지 않으셨다면 이 이메일은 무시해주세요.</p>
-                  </td>
-                </tr>
-                <!-- Vietnamese -->
-                <tr>
-                  <td style="padding-bottom:2rem">
-                    <p style="margin:0;font-size:1rem">Chỉ cần nhấp vào liên kết ở trên để xác minh địa chỉ email của bạn và bắt đầu. Liên kết sẽ hết hạn sau 24 giờ.</p>
-                    <p style="margin:0;font-size:1rem">Nếu bạn chưa đăng ký địa chỉ email với JobForeigner, vui lòng bỏ qua email này.</p>
-                  </td>
-                </tr>
-                <!-- Indian -->
-                <tr>
-                  <td style="padding-bottom:2rem">
-                    <p style="margin:0;font-size:1rem">बस ऊपर दिए गए लिंक पर क्लिक करके अपना ईमेल पता सत्यापित करें और आरंभ करें। लिंक 24 घंटे में समाप्त हो जाएगा।</p>
-                    <p style="margin:0;font-size:1rem">यदि आपने अपना ईमेल पता JobForeigner पर पंजीकृत नहीं किया है, तो कृपया इस ईमेल को अनदेखा करें।</p>
-                  </td>
-                </tr>
-                <!-- Japanese -->
-                <tr>
-                  <td style="padding-bottom:2rem">
-                    <p style="margin:0;font-size:1rem">上記のリンクをクリックしてメールアドレスを確認し、開始してください。リンクは24時間後に有効期限が切れます。</p>
-                    <p style="margin:0;font-size:1rem">JobForeignerにメールアドレスを登録していない場合は、このメールを無視してください。</p>
+                    <p style="margin:0;margin-bottom:1rem;font-size:1rem;font-weight:bold;">Don't know why you received this?</p>
+                    <p style="margin:0;margin-bottom:0.5rem;font-size:1rem">Someone who couldn't remember their account details probably gave your email address by mistake. You can safely ignore this email.</p>
+                    <p style="margin:0;font-size:1rem">To protect your account, don't forward this email or give this code to anyone.</p>
                   </td>
                 </tr>
                 <!-- Footer -->

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -47,7 +47,8 @@ logging:
 job-foreigner:
   mail:
     auth:
-      subject: "[JobForeigner] Please verify your email address."
+      expired-in: 600
+      subject: "( AUTH_CODE ) [JobForeigner] Please verify your email address."
       base-url: "http://localhost:8080"
       verify-path: "/api/v1/email/auth/verify?code="
   open-api:


### PR DESCRIPTION
## What is this PR?🔍
## Changes💻
- 이메일 주소 인증을 링크 방식에서 코드 방식으로 변경합니다.
- 이메일 주소 변경 API를 추가합니다.
- API 문서를 수정합니다.
- `@CurrentMemberId`가 적용된 파라미터가 Swagger에 노출되는 문제를 수정합니다.
- Swagger 접속 시 API 호출 시작 및 완료가 로그에 표시되는 문제를 수정합니다.
- 사용자 ID 필드를 제거합니다. 데이터베이스 수정 작업이 진행되므로 접속되지 않을 수 있습니다.

## ScreenShot📷
<img width="1521" height="1076" alt="image" src="https://github.com/user-attachments/assets/0e0c12e1-2ab7-43a8-b139-3c67b2e34c59" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 외국인 및 기업 회원의 이메일 주소 변경 API가 추가되었습니다.
  * 이메일 인증 코드 검증 방식이 인증 코드와 이메일을 함께 전송하는 방식으로 변경되었습니다.

* **버그 수정**
  * 이메일 인증 관련 API의 동작 방식이 단순화되고, 인증 코드 만료 및 회원 검증 로직이 개선되었습니다.

* **문서화**
  * Swagger/OpenAPI 문서에 태그, 설명, 예시 등이 추가되어 API 명세가 개선되었습니다.

* **스타일**
  * 이메일 인증 메일 템플릿이 간결하게 변경되어 인증 코드만 표시됩니다.

* **환경설정**
  * 메일 서버 연결 및 타임아웃 설정이 20초로 증가되었습니다.

* **기타**
  * 내부 로깅 범위 및 불필요한 필드(예: username) 제거, 인증 코드 저장소가 Redis 기반으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->