### PR TITLE
프론트엔드에서 Authorization 헤더를 읽을 수 있도록 수정

### DIFF
--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/config/security/CorsConfig.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/global/config/security/CorsConfig.java
@@ -22,6 +22,7 @@ public class CorsConfig {
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setMaxAge(3600L);
         configuration.setAllowCredentials(true);
+        configuration.addExposedHeader("Authorization");
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);


### PR DESCRIPTION
## What is this PR?🔍
## Changes💻
- 프론트엔드에서 Authorization 헤더를 읽을 수 있도록 Access-Control-Expose-Headers 헤더를 추가합니다.

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * CORS 설정에서 "Authorization" 헤더가 클라이언트에서 접근 가능하도록 노출되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->