### PR TITLE
docs : 스웨거에서 memberId를 입력받지 않도록 수정

### DIFF
--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/api/MemberApi.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/api/MemberApi.java
@@ -2,6 +2,7 @@ package kr.ac.kumoh.d138.JobForeigner.member.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -39,7 +40,7 @@ public interface MemberApi {
             }
     )
     ResponseEntity<ResponseBody<MemberProfileResponse>> getMyProfile(
-            @CurrentMemberId Long memberId);
+            @Parameter(hidden = true) @CurrentMemberId Long memberId);
 
 
     @Operation(
@@ -58,7 +59,7 @@ public interface MemberApi {
     )
     ResponseEntity<ResponseBody<Void>> updateMyProfile(
             @RequestBody @Valid MemberProfileRequest request,
-            @CurrentMemberId Long memberId);
+            @Parameter(hidden = true) @CurrentMemberId Long memberId);
 
 
     @Operation(
@@ -82,5 +83,5 @@ public interface MemberApi {
                     content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
             )
             @ModelAttribute ProfileImageRequest request,
-            @CurrentMemberId Long memberId);
+            @Parameter(hidden = true) @CurrentMemberId Long memberId);
 }


### PR DESCRIPTION
## What is this PR?🔍
- 스웨거에서 memberId를 필수 매개변수로 표시했던 오류를 수정했습니다

## Changes💻
-  @Parameter(hidden = true)를 사용해 memberId를 스웨거 문서에서 보이지 않도록 했습니다.
- 
- 

## ScreenShot📷
