### PR TITLE
성별 대소문자 구분 않도록 수정

### DIFF
--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/CompanySignUpRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/CompanySignUpRequest.java
@@ -23,7 +23,7 @@ public record CompanySignUpRequest(
         @Email(message = "올바른 이메일 형식이 아닙니다.")
         String email,
         @NotBlank(message = "담당자 성별은 필수 입력 항목입니다.")
-        @Pattern(regexp = "MALE|FEMALE", message = "성별은 MALE 또는 FEMALE이어야 합니다.")
+        @Pattern(regexp = "(?i)MALE|FEMALE", message = "성별은 MALE 또는 FEMALE이어야 합니다.")
         String gender,
         @NotNull(message = "담당자 생년월일은 필수 입력 항목입니다.")
         LocalDate birthDate,

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/ForeignerSignUpRequest.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/dto/request/ForeignerSignUpRequest.java
@@ -21,7 +21,7 @@ public record ForeignerSignUpRequest(
         @Email(message = "올바른 이메일 형식이 아닙니다.")
         String email,
         @NotBlank(message = "성별은 필수 입력 항목입니다.")
-        @Pattern(regexp = "MALE|FEMALE", message = "성별은 MALE 또는 FEMALE이어야 합니다.")
+        @Pattern(regexp = "(?i)MALE|FEMALE", message = "성별은 MALE 또는 FEMALE이어야 합니다.")
         String gender,
         @NotNull(message = "생년월일은 필수 입력 항목입니다.")
         LocalDate birthDate,

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/CompanyMemberService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/CompanyMemberService.java
@@ -49,7 +49,7 @@ public class CompanyMemberService {
                 .companyId(req.companyId())
                 .phoneNumber(req.phoneNumber())
                 .email(req.email())
-                .gender(Gender.valueOf(req.gender()))
+                .gender(Gender.valueOf(req.gender().toUpperCase()))
                 .birthDate(req.birthDate())
                 .profileImageUrl(req.profileImageUrl())
                 .address(new Address(req.address(), req.detailAddress(), req.zipcode()))

--- a/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/ForeignerMemberService.java
+++ b/src/main/java/kr/ac/kumoh/d138/JobForeigner/member/service/ForeignerMemberService.java
@@ -39,7 +39,7 @@ public class ForeignerMemberService {
                 .type(MemberType.FOREIGNER)
                 .phoneNumber(req.phoneNumber())
                 .email(req.email())
-                .gender(Gender.valueOf(req.gender()))
+                .gender(Gender.valueOf(req.gender().toUpperCase()))
                 .birthDate(req.birthDate())
                 .profileImageUrl(req.profileImageUrl())
                 .address(new Address(req.address(), req.detailAddress(), req.zipcode()))


### PR DESCRIPTION
## What is this PR?🔍
## Changes💻
- 성별 대소문자를 깐깐하게 비교하지 않고 rough하게 비교하여 대문자와 소문자 모두 사용할 수 있도록 합니다.

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 회원가입 시 성별 입력값이 대소문자 구분 없이 인식되도록 개선되었습니다. 이제 "male", "MALE", "Male", "female" 등 다양한 형태로 입력해도 정상적으로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->